### PR TITLE
Implement support for realtime API and change to better table component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,8 @@ module.exports = {
     extends: [
         'plugin:react/recommended', // Uses the recommended rules from @eslint-plugin-react
         'plugin:@typescript-eslint/recommended', // Uses the recommended rules from @typescript-eslint/eslint-plugin
+        'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+        'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
     ],
     rules: {
         // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,8 +15,6 @@ module.exports = {
     extends: [
         'plugin:react/recommended', // Uses the recommended rules from @eslint-plugin-react
         'plugin:@typescript-eslint/recommended', // Uses the recommended rules from @typescript-eslint/eslint-plugin
-        'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
-        'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
     ],
     rules: {
         // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs

--- a/package-lock.json
+++ b/package-lock.json
@@ -10147,9 +10147,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4639,6 +4639,52 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/react-select": "*",
     "@types/react-table": "^6.0.0",
     "axios": "*",
+    "cross-env": "^7.0.2",
     "react": "*",
     "react-cookie": "*",
     "react-dom": "*",
@@ -30,7 +31,7 @@
     "typescript": "*"
   },
   "scripts": {
-    "start": "HTTPS=true PORT=4443 react-scripts start",
+    "start": "cross-env HTTPS=true PORT=4443 react-scripts start",
     "debug": "react-scripts start",
     "build": "react-scripts build",
     "lint": "eslint src --ext .ts,.tsx,.js",

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -129,7 +129,9 @@ export interface IncidentProblemType {
 
 export interface Incident {
   pk: number;
-  timestamp: string;
+  start_time: string;
+  end_time?: string;
+  stateful: boolean;
   incident_id: string;
   details_url: string;
   description: string;
@@ -314,16 +316,16 @@ export class ApiClient {
 
   public getUser(userPK: number): Promise<User> {
     return resolveOrReject(
-        this.authGet<User, {}>(`/api/v1/auth/users/${userPK}/`),
-        defaultResolver,
-        (error) => new Error(`Failed to get user: ${error}`),
+      this.authGet<User, {}>(`/api/v1/auth/users/${userPK}/`),
+      defaultResolver,
+      (error) => new Error(`Failed to get user: ${error}`),
     );
   }
 
   // NotificationProfile
   public getNotificationProfile(timeslot: TimeslotPK): Promise<NotificationProfile> {
     return resolveOrReject(
-      this.authGet<NotificationProfile, GetNotificationProfileRequest>(`/api/v1/notificationprofile/${timeslot}`),
+      this.authGet<NotificationProfile, GetNotificationProfileRequest>(`/api/v1/notificationprofile/${timeslot}/`),
       defaultResolver,
       (error) => new Error(`Failed to get notification profile: ${error}`),
     );
@@ -345,7 +347,7 @@ export class ApiClient {
   ): Promise<NotificationProfile> {
     return resolveOrReject(
       this.authPut<NotificationProfileSuccessResponse, NotificationProfileRequest>(
-        `/api/v1/notificationprofiles/${timeslot}`,
+        `/api/v1/notificationprofiles/${timeslot}/`,
         {
           timeslot: timeslot,
           filters,
@@ -379,7 +381,7 @@ export class ApiClient {
 
   public deleteNotificationProfile(profile: NotificationProfilePK): Promise<boolean> {
     return this.authDelete<NotificationProfileSuccessResponse, DeleteNotificationProfileRequest>(
-      `/api/v1/notificationprofiles/${profile}`,
+      `/api/v1/notificationprofiles/${profile}/`,
     )
       .then(() => {
         return Promise.resolve(true);
@@ -413,9 +415,9 @@ export class ApiClient {
 
   public postIncidentCloseEvent(pk: number): Promise<Event> {
     return resolveOrReject(
-        this.authPost<Event, EventWithoutDescriptionBody>(`/api/v1/incidents/${pk}/events/`, { type: EventType.CLOSE }),
-        defaultResolver,
-        (error) => new Error(`Failed to post incident close event: ${error}`),
+      this.authPost<Event, EventWithoutDescriptionBody>(`/api/v1/incidents/${pk}/events/`, { type: EventType.CLOSE }),
+      defaultResolver,
+      (error) => new Error(`Failed to post incident close event: ${error}`),
     );
   }
 
@@ -483,7 +485,7 @@ export class ApiClient {
 
   public deleteFilter(pk: FilterPK): Promise<void> {
     return resolveOrReject(
-      this.authDelete<never, never>(`/api/v1/notificationprofiles/filters/${pk}`),
+      this.authDelete<never, never>(`/api/v1/notificationprofiles/filters/${pk}/`),
       defaultResolver,
       (error) => new Error(`Failed to delete notification filter ${pk}: ${error}`),
     );
@@ -500,7 +502,7 @@ export class ApiClient {
 
   public deleteTimeslot(timeslotPK: TimeslotPK): Promise<boolean> {
     return resolveOrReject(
-      this.authDelete<boolean, never>(`/api/v1/notificationprofiles/timeslots/${timeslotPK}`),
+      this.authDelete<boolean, never>(`/api/v1/notificationprofiles/timeslots/${timeslotPK}/`),
       () => true,
       (error) => new Error(`Failed to delete notificationprofile timeslots: ${error}`),
     );
@@ -508,7 +510,7 @@ export class ApiClient {
 
   public putTimeslot(timeslotPK: TimeslotPK, name: string, timeRecurrences: TimeRecurrence[]): Promise<Timeslot> {
     return resolveOrReject(
-      this.authPut<Timeslot, Omit<Timeslot, "pk">>(`/api/v1/notificationprofiles/timeslots/${timeslotPK}`, {
+      this.authPut<Timeslot, Omit<Timeslot, "pk">>(`/api/v1/notificationprofiles/timeslots/${timeslotPK}/`, {
         name,
         // eslint-disable-next-line
         time_recurrences: timeRecurrences,
@@ -533,9 +535,9 @@ export class ApiClient {
   // Acknowledgements
   public postAck(incidentPK: number, ack: AcknowledgementBody): Promise<Acknowledgement> {
     return resolveOrReject(
-        this.authPost<Acknowledgement, AcknowledgementBody>(`/api/v1/incidents/${incidentPK}/acks/`, ack),
-        defaultResolver,
-        (error) => new Error(`Failed to post incident ack: ${error}`),
+      this.authPost<Acknowledgement, AcknowledgementBody>(`/api/v1/incidents/${incidentPK}/acks/`, ack),
+      defaultResolver,
+      (error) => new Error(`Failed to post incident ack: ${error}`),
     );
   }
 
@@ -577,7 +579,7 @@ export class ApiClient {
 
   private authPatch<T, B, R = AxiosResponse<T>>(url: string, data?: B, config?: AxiosRequestConfig): Promise<R> {
     return this.mustBeAuthenticated((token: Token) =>
-        this.api.patch(url, data, configWithAuth(config || this.config, token)),
+      this.api.patch(url, data, configWithAuth(config || this.config, token)),
     );
   }
 

--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -18,6 +18,7 @@ class Auth {
     if (callback) callback();
   }
   logout(callback?: () => void) {
+    // TODO: log out using `api.postLogout()`
     this.authenticated = false;
     this._token = undefined;
     cookies.remove("token");

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -24,7 +24,7 @@ const Userbutton: React.FC<UserbuttonPropsType> = (props: UserbuttonPropsType) =
             auth.logout(() => props.history.push("/login"));
           }}
         >
-          Logout
+          Log out
         </button>
       </div>
     </div>

--- a/src/components/incident/Chips.tsx
+++ b/src/components/incident/Chips.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import Chip from "@material-ui/core/Chip";
+import { Timestamp } from "../../api";
+
+import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
+import { WHITE } from "../../colorscheme";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    closed: {
+      background: theme.palette.success.main,
+      color: WHITE,
+    },
+    open: {
+      background: theme.palette.warning.main,
+      color: WHITE,
+    },
+    acknowledged: {
+      background: theme.palette.success.main,
+      color: WHITE,
+    },
+    unacknowledged: {
+      background: theme.palette.warning.main,
+      color: WHITE,
+    },
+    notticketed: {
+      background: theme.palette.warning.main,
+      color: WHITE,
+    },
+    ticketed: {
+      background: theme.palette.success.main,
+      color: WHITE,
+    },
+  }),
+);
+
+export type OpenItemPropsType = {
+  open: boolean;
+  small?: boolean;
+};
+
+export const OpenItem: React.FC<OpenItemPropsType> = ({ open, small }: OpenItemPropsType) => {
+  const classes = useStyles();
+  return (
+    <Chip
+      size={(small && "small") || undefined}
+      variant="outlined"
+      className={open ? classes.open : classes.closed}
+      label={open ? "Open" : "Closed"}
+    />
+  );
+};
+
+type AckedItemPropsType = {
+  acked: boolean;
+  expiration?: Timestamp | null;
+  small?: boolean;
+};
+
+export const AckedItem: React.FC<AckedItemPropsType> = ({ acked, expiration, small }: AckedItemPropsType) => {
+  const classes = useStyles();
+
+  const expiryDate = expiration && new Date(expiration);
+  if (small) {
+    return (
+      <Chip
+        size="small"
+        className={acked ? classes.acknowledged : classes.unacknowledged}
+        label={acked ? "Acked" : "Non-acked"}
+      />
+    );
+  }
+  return (
+    <Chip
+      className={acked ? classes.acknowledged : classes.unacknowledged}
+      label={acked ? (expiryDate ? `Acknowledged until ${expiryDate}` : "Acknowledged") : "Unacknowledged"}
+    />
+  );
+};
+
+type TicketItemPropsType = {
+  ticketUrl?: string;
+  small?: boolean;
+};
+
+export const TicketItem: React.FC<TicketItemPropsType> = ({ ticketUrl, small }: TicketItemPropsType) => {
+  const classes = useStyles();
+
+  const chipProps =
+    (ticketUrl && {
+      component: "a",
+      href: ticketUrl,
+      clickable: true,
+    }) ||
+    {};
+
+  if (small) {
+    return (
+      <Chip
+        size="small"
+        variant="outlined"
+        className={ticketUrl ? classes.ticketed : classes.notticketed}
+        label={ticketUrl ? `Ticket` : "No ticket"}
+        {...chipProps}
+      />
+    );
+  }
+
+  return (
+    <Chip
+      variant="outlined"
+      className={ticketUrl ? classes.ticketed : classes.notticketed}
+      label={ticketUrl ? `Ticket ${ticketUrl}` : "No ticket"}
+      {...chipProps}
+    />
+  );
+};

--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -1,0 +1,554 @@
+import React, { useState, useMemo } from "react";
+// import "./incidenttable.css";
+import "react-table/react-table.css";
+
+import Button from "@material-ui/core/Button";
+import EditIcon from "@material-ui/icons/Edit";
+import Grid from "@material-ui/core/Grid";
+
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemText from "@material-ui/core/ListItemText";
+
+import Chip from "@material-ui/core/Chip";
+
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+
+import TextField from "@material-ui/core/TextField";
+import Typography from "@material-ui/core/Typography";
+
+import DateFnsUtils from "@date-io/date-fns";
+import { MuiPickersUtilsProvider, KeyboardDatePicker } from "@material-ui/pickers";
+
+import { useStateWithDynamicDefault } from "../../utils";
+
+import { makeConfirmationButton } from "../../components/buttons/ConfirmationButton";
+import { UseAlertSnackbarResultType } from "../../components/alertsnackbar";
+import CenterContainer from "../../components/centercontainer";
+
+import api, { Event, EventType, Incident, Acknowledgement, AcknowledgementBody } from "../../api";
+
+import SignedMessage from "./SignedMessage";
+import SignOffAction from "./SignOffAction";
+import { useStyles } from "./styles";
+
+import { AckedItem, OpenItem, TicketItem } from "../incident/Chips";
+
+type IncidentDetailsListItemPropsType = {
+  title: string;
+  detail: string | React.ReactNode;
+};
+
+const IncidentDetailsListItem: React.FC<IncidentDetailsListItemPropsType> = ({
+  title,
+  detail,
+}: IncidentDetailsListItemPropsType) => {
+  return (
+    <ListItem>
+      <ListItemText primary={title} secondary={detail} />
+    </ListItem>
+  );
+};
+
+type EventListItemPropsType = {
+  event: Event;
+};
+
+const EventListItem: React.FC<EventListItemPropsType> = ({ event }: EventListItemPropsType) => {
+  return (
+    <ListItem>
+      <ListItemText primary="Name" secondary={event.type.display} />
+    </ListItem>
+  );
+};
+
+type Tag = {
+  key: string;
+  value: string;
+};
+
+type TagChipPropsType = {
+  tag: Tag;
+  small?: boolean;
+};
+
+const isValidUrl = (url: string) => {
+  // Pavlo's answer at
+  // https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
+  try {
+    new URL(url);
+  } catch (_) {
+    return false;
+  }
+  return true;
+};
+
+const TagChip: React.FC<TagChipPropsType> = ({ tag, small }: TagChipPropsType) => {
+  if (isValidUrl(tag.value)) {
+    return (
+      <Chip
+        size={(small && "small") || undefined}
+        label={`${tag.key}=${tag.value}`}
+        component="a"
+        href={tag.value}
+        clickable
+      />
+    );
+  }
+  return <Chip size={(small && "small") || undefined} label={`${tag.key}=${tag.value}`} />;
+};
+
+type TicketModifiableFieldPropsType = {
+  url?: string;
+  saveChange: (newUrl?: string) => void;
+};
+
+const TicketModifiableField: React.FC<TicketModifiableFieldPropsType> = ({
+  url: urlProp,
+  saveChange,
+}: TicketModifiableFieldPropsType) => {
+  const classes = useStyles();
+
+  const [changeUrl, setChangeUrl] = useState<boolean>(false);
+  const [url, setUrl] = useStateWithDynamicDefault<string | undefined>(urlProp);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setUrl(event.target.value);
+    setChangeUrl(true);
+  };
+
+  const handleSave = () => {
+    // If url is empty string ("") store it as undefined.
+    if (url !== undefined && changeUrl) saveChange(url || undefined);
+    setChangeUrl(false);
+  };
+
+  const error = useMemo(() => !isValidUrl(url || ""), [url]);
+
+  return (
+    <ListItem>
+      <Grid container direction="row" justify="space-between">
+        <TextField
+          label="Ticket"
+          defaultValue={url || ""}
+          InputProps={{
+            readOnly: !changeUrl,
+          }}
+          onChange={handleChange}
+          error={error}
+          helperText={error && "Invalid URL"}
+        />
+        {(!changeUrl && (
+          <Button endIcon={<EditIcon />} onClick={() => setChangeUrl(true)}>
+            Edit
+          </Button>
+        )) || (
+          <Button className={classes.safeButton} onClick={() => handleSave()} disabled={error}>
+            Set ticket URL
+          </Button>
+        )}
+      </Grid>
+    </ListItem>
+  );
+};
+
+type AckListItemPropsType = {
+  ack: Acknowledgement;
+};
+
+const AckListItem: React.FC<AckListItemPropsType> = ({ ack }: AckListItemPropsType) => {
+  const classes = useStyles();
+
+  const ackDate = new Date(ack.event.timestamp);
+  const formattedAckDate = ackDate.toLocaleString();
+
+  let hasExpired = false;
+  let expiresMessage;
+  if (ack.expiration) {
+    const date = new Date(ack.expiration);
+    if (Date.parse(ack.expiration) < Date.now()) {
+      expiresMessage = `Expired ${date.toLocaleString()}`;
+      hasExpired = true;
+    } else {
+      expiresMessage = `Expires ${date.toLocaleString()}`;
+    }
+  }
+
+  return (
+    <div className={classes.message}>
+      <SignedMessage
+        message={ack.event.description}
+        timestamp={formattedAckDate}
+        user={ack.event.actor}
+        content={
+          <ListItemText
+            primary={expiresMessage || ""}
+            secondary={
+              <Typography paragraph style={{ textDecoration: hasExpired ? "line-through" : "none" }}>
+                {ack.event.description}
+              </Typography>
+            }
+          />
+        }
+      />
+    </div>
+  );
+};
+
+type CreateAckPropsType = {
+  onSubmitAck: (ack: AcknowledgementBody) => void;
+};
+
+const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck }: CreateAckPropsType) => {
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  const handleSubmit = (msg: string) => {
+    // TODO: switch to use API when implemented in backend
+    onSubmitAck({
+      event: {
+        description: msg,
+      },
+      expiration: selectedDate && selectedDate.toUTCString(),
+    });
+  };
+
+  const handleDateChange = (date: Date | null) => {
+    setSelectedDate(date);
+  };
+
+  return (
+    <SignOffAction
+      dialogTitle="Submit acknowledment"
+      dialogContentText="Write a message describing why this incident was acknowledged "
+      dialogSubmitText="Submit"
+      dialogCancelText="Cancel"
+      dialogButtonText="Create acknowledegment"
+      title="Submit acknowledment"
+      question="Are you sure you want to acknowledge this incident?"
+      onSubmit={handleSubmit}
+    >
+      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+        <KeyboardDatePicker
+          disableToolbar
+          format="MM/dd/yyyy"
+          margin="normal"
+          id="expiry-date"
+          label="Expiry date"
+          value={selectedDate}
+          onChange={handleDateChange}
+          KeyboardButtonProps={{
+            "aria-label": "change date",
+          }}
+        />
+      </MuiPickersUtilsProvider>
+    </SignOffAction>
+  );
+};
+
+type ManualClosePropsType = {
+  open: boolean;
+  onManualClose: (msg: string) => void;
+  onManualOpen: () => void;
+};
+
+const ManualClose: React.FC<ManualClosePropsType> = ({ open, onManualClose, onManualOpen }: ManualClosePropsType) => {
+  const classes = useStyles();
+
+  if (open) {
+    return (
+      <SignOffAction
+        dialogTitle="Manually close incident"
+        dialogContentText="Write a message describing why the incident was manually closed"
+        dialogSubmitText="Close now"
+        dialogCancelText="Cancel"
+        dialogButtonText="Close incident"
+        title="Manually close incident"
+        question="Are you sure you want to close this incident?"
+        onSubmit={onManualClose}
+      />
+    );
+  } else {
+    const ReopenButton = makeConfirmationButton({
+      title: "Reopen incident",
+      question: "Are you sure you want to reopen this incident?",
+      onConfirm: onManualOpen,
+    });
+
+    return (
+      <ReopenButton variant="contained" className={classes.dangerousButton}>
+        Reopen incident
+      </ReopenButton>
+    );
+  }
+};
+
+type IncidentDetailsPropsType = {
+  incident: Incident;
+  onIncidentChange: (incident: Incident) => void;
+  displayAlertSnackbar: UseAlertSnackbarResultType["displayAlertSnackbar"];
+};
+
+const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
+  incident,
+  onIncidentChange,
+  displayAlertSnackbar,
+}: IncidentDetailsPropsType) => {
+  const classes = useStyles();
+
+  // const [ticketUrl, setTicketUrl] = useState<string | undefined>(incident && incident.ticket_url);
+  // const [active, setActive] = useState<boolean>((incident && incident.active) || false);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  //onst { incidentSnackbar, displayAlertSnackbar }: UseAlertSnackbarResultType = useAlertSnackbar();
+  // TODO: handle close message
+
+  // TODO: users should be represented by username...
+  const defaultEvent1 = {
+    pk: 1,
+    incident: 1,
+    actor: 2,
+    timestamp: "2020-01-14T03:04:14.387000+01:00",
+    type: {
+      value: EventType.ACKNOWLEDGE,
+      display: "Acknowledge",
+    },
+    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vulputate id erat non pretium.",
+  };
+  const defaultEvent2 = {
+    pk: 2,
+    incident: 1,
+    actor: 1,
+    timestamp: "2020-01-15T03:04:14.387000+01:00",
+    type: {
+      value: EventType.ACKNOWLEDGE,
+      display: "Acknowledge",
+    },
+    description: "Ack ack",
+  };
+
+  const defaultAcks = [
+    {
+      user: "testuser2",
+      timestamp: "2020-01-14T03:04:14.387000+01:00",
+      message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vulputate id erat non pretium.",
+      expiresAt: "2020-02-14T03:04:14.387000+01:00",
+      pk: 1,
+      event: defaultEvent1,
+      expiration: "2020-02-14T15:04:14.387000+01:00",
+    },
+    {
+      user: "testuser",
+      timestamp: "2020-01-15T03:04:14.387000+01:00",
+      message: "Ack ack",
+      expiresAt: null,
+      pk: 2,
+      event: defaultEvent2,
+      expiration: null,
+    },
+  ];
+
+  const [acks, setAcks] = useState<Acknowledgement[]>(defaultAcks);
+
+  const chronoAcks = useMemo<Acknowledgement[]>(() => {
+    return [...acks].sort((first: Acknowledgement, second: Acknowledgement) => {
+      const firstTime = Date.parse(first.event.timestamp);
+      const secondTime = Date.parse(second.event.timestamp);
+      if (firstTime < secondTime) {
+        return 1;
+      } else if (firstTime > secondTime) {
+        return -1;
+      }
+      if (first.expiration && second.expiration) {
+        const firstExpires = Date.parse(first.expiration);
+        const secondExpires = Date.parse(second.expiration);
+        return firstExpires < secondExpires ? 1 : firstExpires > secondExpires ? -1 : 0;
+      }
+      return first.expiration ? 1 : -1;
+    });
+  }, [acks]);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const handleManualClose = (msg: string) => {
+    api
+      .postIncidentCloseEvent(incident.pk)
+      .then((event: Event) => {
+        // TODO: add close event to list of events
+        displayAlertSnackbar(`Closed incident ${incident && incident.pk}`, "success");
+        onIncidentChange({ ...incident, open: false });
+      })
+      .catch((error) => {
+        displayAlertSnackbar(`Failed to close incident ${incident && incident.pk} - ${error}`, "error");
+      });
+  };
+
+  const handleManualOpen = () => {
+    api
+      .postIncidentReopenEvent(incident.pk)
+      .then((event: Event) => {
+        // TODO: add open event to list of events
+        displayAlertSnackbar(`Reopened incident ${incident && incident.pk}`, "success");
+        onIncidentChange({ ...incident, open: true });
+      })
+      .catch((error) => {
+        displayAlertSnackbar(`Failed to reopen incident ${incident && incident.pk} - ${error}`, "error");
+      });
+  };
+
+  const ackExpiryDate = undefined;
+
+  // TODO: get tag from incident
+  const tags = [
+    { key: "test_url", value: "https://uninett.no" },
+    { key: "test_host", value: "uninett.no" },
+    { key: "host", value: "uninett.no" },
+    { key: "timestamp", value: "123123123" },
+    { key: "bytes", value: "askldfjalskdf" },
+    { key: "origin_src", value: "something.tst" },
+  ];
+
+  // {incidentSnackbar}
+  return (
+    <div className={classes.root}>
+      <Grid container spacing={3} className={classes.grid}>
+        <Grid container item spacing={2} md alignItems="stretch" justify="space-evenly" direction="column">
+          <Grid item>
+            <Card>
+              <CardContent>
+                <Typography color="textSecondary" gutterBottom>
+                  Status
+                </Typography>
+                <CenterContainer>
+                  <OpenItem open={incident.open} />
+                  <AckedItem acked={true} expiration={ackExpiryDate} />
+                  <TicketItem ticketUrl={incident.ticket_url} />
+                </CenterContainer>
+              </CardContent>
+            </Card>
+          </Grid>
+
+          {!incident.open && (
+            <Grid item>
+              <Card>
+                <CardContent>
+                  <Typography color="textSecondary" gutterBottom>
+                    Incident closed
+                  </Typography>
+                  <SignedMessage
+                    message={"Incident was resolved on servicerestart"}
+                    content={<Typography paragraph>Incident was resolved on servicerestart</Typography>}
+                    timestamp={new Date().toUTCString()}
+                    user={"you"}
+                    TextComponent={Typography}
+                  />
+                </CardContent>
+              </Card>
+            </Grid>
+          )}
+
+          <Grid item>
+            <Card>
+              <CardContent>
+                <Typography color="textSecondary" gutterBottom>
+                  Tags
+                </Typography>
+                {tags.map((tag: Tag) => (
+                  <TagChip key={tag.key} tag={tag} />
+                ))}
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid item>
+            <Card>
+              <CardContent>
+                <Typography color="textSecondary" gutterBottom>
+                  Primary details
+                </Typography>
+                <List>
+                  <IncidentDetailsListItem title="Description" detail={incident.description} />
+                  <IncidentDetailsListItem title="Start time" detail={incident.start_time} />
+                  <IncidentDetailsListItem title="Source" detail={incident.source.name} />
+                  <IncidentDetailsListItem
+                    title="Details URL"
+                    detail={<a href={incident.details_url}>{incident.details_url}</a>}
+                  />
+
+                  <TicketModifiableField
+                    url={incident.ticket_url}
+                    saveChange={(url?: string) => {
+                      // TODO: api
+                      api
+                        .patchIncidentTicketUrl(incident.pk, url || "")
+                        .then((incident: Incident) => {
+                          displayAlertSnackbar(`Updated ticket URL for ${incident.pk}`, "success");
+                          onIncidentChange(incident);
+                        })
+                        .catch((error) => {
+                          displayAlertSnackbar(`Failed to updated ticket URL ${error}`, "error");
+                        });
+                    }}
+                  />
+                  <ListItem>
+                    <CenterContainer>
+                      <ManualClose
+                        open={incident.open}
+                        onManualClose={handleManualClose}
+                        onManualOpen={handleManualOpen}
+                      />
+                    </CenterContainer>
+                  </ListItem>
+                </List>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+
+        <Grid container item spacing={2} md direction="column">
+          <Grid item>
+            <Typography color="textSecondary" gutterBottom>
+              Acknowledgements
+            </Typography>
+            <List>
+              {chronoAcks.map((ack: Acknowledgement) => (
+                <AckListItem key={ack.event.timestamp} ack={ack} />
+              ))}
+            </List>
+            <CenterContainer>
+              <CreateAck
+                key={acks.length}
+                onSubmitAck={(ack: AcknowledgementBody) => {
+                  // TODO: handle ack submit here
+                  console.log(ack);
+                  api
+                    .postAck(incident.pk, ack)
+                    .then((ack: Acknowledgement) => {
+                      displayAlertSnackbar(`Submitted ack for ${incident && incident.pk}`, "success");
+                      setAcks([...acks, ack]);
+                    })
+                    .catch((error) => {
+                      displayAlertSnackbar(`Failed to post ack ${error}`, "error");
+                    });
+                }}
+              />
+            </CenterContainer>
+          </Grid>
+          <Grid item>
+            <Card>
+              <CardContent>
+                <Typography color="textSecondary" gutterBottom>
+                  Related events
+                </Typography>
+                <List>
+                  <EventListItem event={defaultEvent1} />
+                  <EventListItem event={defaultEvent2} />
+                </List>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export default IncidentDetails;

--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -371,6 +371,7 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
   const handleManualClose = (msg: string) => {
     api
       .postIncidentCloseEvent(incident.pk)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .then((event: Event) => {
         // TODO: add close event to list of events
         displayAlertSnackbar(`Closed incident ${incident && incident.pk}`, "success");
@@ -384,6 +385,7 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
   const handleManualOpen = () => {
     api
       .postIncidentReopenEvent(incident.pk)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .then((event: Event) => {
         // TODO: add open event to list of events
         displayAlertSnackbar(`Reopened incident ${incident && incident.pk}`, "success");

--- a/src/components/incident/SignOffAction.tsx
+++ b/src/components/incident/SignOffAction.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import TextField from "@material-ui/core/TextField";
+
+import { makeConfirmationButton } from "../../components/buttons/ConfirmationButton";
+
+import { useStyles } from "./styles";
+
+type SignOffActionPropsType = {
+  dialogTitle: string;
+  dialogContentText: string;
+  dialogCancelText: string;
+  dialogSubmitText: string;
+  dialogButtonText: string;
+  title: string;
+  question: string;
+  confirmName?: string;
+  rejectName?: string;
+  onSubmit: (msg: string) => void;
+  children?: React.Props<{}>["children"];
+};
+
+const SignOffAction: React.FC<SignOffActionPropsType> = ({
+  dialogTitle,
+  dialogContentText,
+  dialogCancelText,
+  dialogSubmitText,
+  dialogButtonText,
+  title,
+  question,
+  confirmName,
+  rejectName,
+  onSubmit,
+  children,
+}: SignOffActionPropsType) => {
+  const classes = useStyles();
+
+  const [open, setOpen] = useState<boolean>(false);
+  const [message, setMessage] = useState<string | undefined>(undefined);
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const onConfirm = () => {
+    handleClose();
+    if (message) onSubmit(message);
+  };
+
+  const handleMessageChange = (e: React.ChangeEvent<HTMLInputElement>) => setMessage(e.target.value);
+
+  const CloseButton = makeConfirmationButton({
+    title,
+    question,
+    confirmName,
+    rejectName,
+    onConfirm,
+  });
+
+  return (
+    <div>
+      <Button onClick={handleOpen} className={classes.dangerousButton}>
+        {dialogButtonText}
+      </Button>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>{dialogTitle}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{dialogContentText}</DialogContentText>
+          <TextField
+            autoFocus
+            margin="dense"
+            id="messsage"
+            label="Messsage"
+            type="text"
+            fullWidth
+            value={message || ""}
+            onChange={handleMessageChange}
+          />
+          {children}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} className={classes.safeButton}>
+            {dialogCancelText}
+          </Button>
+          <CloseButton onClick={onConfirm} variant="contained" className={classes.dangerousButton}>
+            {dialogSubmitText}
+          </CloseButton>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default SignOffAction;

--- a/src/components/incident/SignedMessage.tsx
+++ b/src/components/incident/SignedMessage.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import ListItemText from "@material-ui/core/ListItemText";
+import Grid from "@material-ui/core/Grid";
+
+import { Timestamp } from "../../api";
+
+type SignedMessagePropsType = {
+  message: string;
+  user: string | number; // FIXME: should be username of course...
+  timestamp: Timestamp;
+
+  content?: React.ReactNode;
+  TextComponent?: React.ComponentType;
+};
+
+const SignedMessage: React.FC<SignedMessagePropsType> = ({
+  message,
+  user,
+  timestamp,
+  content,
+  TextComponent,
+}: SignedMessagePropsType) => {
+  const ackDate = new Date(timestamp);
+  const formattedAckDate = ackDate.toLocaleString();
+
+  const Component: React.ComponentType = TextComponent || ListItemText;
+
+  return (
+    <Grid container direction="column" spacing={2}>
+      {content || <Component>{message}</Component>}
+
+      <Grid container direction="row" spacing={2}>
+        <Grid item sm>
+          <Component>{user}</Component>
+        </Grid>
+        <Grid item container sm alignItems="flex-end" justify="space-evenly">
+          <Component>{formattedAckDate}</Component>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default SignedMessage;

--- a/src/components/incident/styles.tsx
+++ b/src/components/incident/styles.tsx
@@ -1,0 +1,41 @@
+import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
+import { WHITE } from "../../colorscheme";
+
+export const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      backgroundColor: theme.palette.background.paper,
+      boxShadow: theme.shadows[5],
+      padding: theme.spacing(2, 4, 3),
+    },
+    closeIcon: {
+      marginRight: theme.spacing(2),
+    },
+    title: {
+      marginLeft: theme.spacing(2),
+      flex: 1,
+    },
+    grid: {
+      "flex-wrap": "wrap",
+      "align-items": "stretch",
+      "align-content": "stretch",
+    },
+    dangerousButton: {
+      background: theme.palette.warning.main,
+      color: WHITE,
+    },
+    safeButton: {
+      background: theme.palette.primary.main,
+      color: WHITE,
+    },
+    message: {
+      backgroundColor: theme.palette.background.paper,
+      boxShadow: theme.shadows[2],
+      padding: theme.spacing(2, 4, 3),
+    },
+    closedMessage: {
+      backgroundColor: theme.palette.success.main,
+      color: WHITE,
+    },
+  }),
+);

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -1,867 +1,316 @@
-import React, { useState, useMemo } from "react";
-import "./incidenttable.css";
-import "react-table/react-table.css";
+import React, { useEffect, useState, useMemo } from "react";
 
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
 import AppBar from "@material-ui/core/AppBar";
 import Dialog from "@material-ui/core/Dialog";
-import DialogActions from "@material-ui/core/DialogActions";
-import DialogTitle from "@material-ui/core/DialogTitle";
-import DialogContent from "@material-ui/core/DialogContent";
-import DialogContentText from "@material-ui/core/DialogContentText";
 import Toolbar from "@material-ui/core/Toolbar";
+import Tooltip from "@material-ui/core/Tooltip";
 import IconButton from "@material-ui/core/IconButton";
 import CloseIcon from "@material-ui/icons/Close";
-import EditIcon from "@material-ui/icons/Edit";
-import Grid from "@material-ui/core/Grid";
+import FilterListIcon from "@material-ui/icons/FilterList";
+import CheckSharpIcon from "@material-ui/icons/CheckSharp";
+import LinkSharpIcon from "@material-ui/icons/LinkSharp";
+import Paper from "@material-ui/core/Paper";
+import Checkbox from "@material-ui/core/Checkbox";
 
-import List from "@material-ui/core/List";
-import ListItem from "@material-ui/core/ListItem";
-import ListItemText from "@material-ui/core/ListItemText";
-
-import Chip from "@material-ui/core/Chip";
-
-import Card from "@material-ui/core/Card";
-import CardContent from "@material-ui/core/CardContent";
-
-import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 
 import ClickAwayListener from "@material-ui/core/ClickAwayListener";
+import MuiTable from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell, { TableCellProps } from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import TablePagination from "@material-ui/core/TablePagination";
 
-import DateFnsUtils from "@date-io/date-fns";
-import { MuiPickersUtilsProvider, KeyboardDatePicker } from "@material-ui/pickers";
-
-// TODO: remove incidentWithFormattedTimestamp
-// use regular incident instead.
 import { useStateWithDynamicDefault, toMap, pkGetter } from "../../utils";
-import Table, {
-  Accessor,
-  getMaxColumnWidth,
-  maxWidthColumn,
-  calculateTableCellWidth,
-  ConstraintFunction,
-} from "../table/Table";
 
-import { WHITE } from "../../colorscheme";
-import { makeConfirmationButton } from "../../components/buttons/ConfirmationButton";
 import { useAlertSnackbar, UseAlertSnackbarResultType } from "../../components/alertsnackbar";
-import CenterContainer from "../../components/centercontainer";
 
 import api, { Incident, Event, EventType, Acknowledgement, AcknowledgementBody, Timestamp } from "../../api";
+import { BACKEND_WS_URL } from "../../config";
+import { useStyles } from "../incident/styles";
+import { AckedItem, OpenItem, TicketItem } from "../incident/Chips";
+import IncidentDetails from "../incident/IncidentDetails";
 
-const useStyles = makeStyles((theme: Theme) =>
+const useToolbarStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      backgroundColor: theme.palette.background.paper,
-      boxShadow: theme.shadows[5],
-      padding: theme.spacing(2, 4, 3),
-    },
-    closeIcon: {
-      marginRight: theme.spacing(2),
+      paddingLeft: theme.spacing(2),
+      paddingRight: theme.spacing(1),
     },
     title: {
-      marginLeft: theme.spacing(2),
-      flex: 1,
-    },
-    grid: {
-      "flex-wrap": "wrap",
-      "align-items": "stretch",
-      "align-content": "stretch",
-    },
-    dangerousButton: {
-      background: theme.palette.warning.main,
-      color: WHITE,
-    },
-    safeButton: {
-      background: theme.palette.primary.main,
-      color: WHITE,
-    },
-    closed: {
-      background: theme.palette.success.main,
-      color: WHITE,
-    },
-    open: {
-      background: theme.palette.warning.main,
-      color: WHITE,
-    },
-    acknowledged: {
-      background: theme.palette.success.main,
-      color: WHITE,
-    },
-    unacknowledged: {
-      background: theme.palette.warning.main,
-      color: WHITE,
-    },
-    notticketed: {
-      background: theme.palette.warning.main,
-      color: WHITE,
-    },
-    ticketed: {
-      background: theme.palette.success.main,
-      color: WHITE,
-    },
-    message: {
-      backgroundColor: theme.palette.background.paper,
-      boxShadow: theme.shadows[2],
-      padding: theme.spacing(2, 4, 3),
-    },
-    closedMessage: {
-      backgroundColor: theme.palette.success.main,
-      color: WHITE,
+      flex: "1 1 100%",
     },
   }),
 );
 
-type IncidentDetailListItemPropsType = {
-  title: string;
-  detail: string | React.ReactNode;
-};
+interface TableToolbarPropsType {
+  selectedIncidents: Set<Incident["pk"]> | "SelectedAll";
+}
 
-const IncidentDetailListItem: React.FC<IncidentDetailListItemPropsType> = ({
-  title,
-  detail,
-}: IncidentDetailListItemPropsType) => {
+const TableToolbar: React.FC<TableToolbarPropsType> = ({ selectedIncidents }: TableToolbarPropsType) => {
+  const classes = useToolbarStyles();
+  const rootClasses = useStyles();
+
   return (
-    <ListItem>
-      <ListItemText primary={title} secondary={detail} />
-    </ListItem>
+    <Toolbar className={classes.root}>
+      {selectedIncidents === "SelectedAll" || selectedIncidents.size > 0 ? (
+        <Typography className={classes.title} color="inherit" variant="subtitle1" component="div">
+          {selectedIncidents === "SelectedAll" ? "All" : selectedIncidents.size} selected
+        </Typography>
+      ) : (
+        <Typography className={classes.title} variant="h6" id="tableTitle" component="div">
+          Incidents
+        </Typography>
+      )}
+
+      {selectedIncidents === "SelectedAll" || selectedIncidents.size > 0 ? (
+        <>
+          <Tooltip title="Link">
+            <IconButton aria-label="link" className={rootClasses.safeButton}>
+              <LinkSharpIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Acknowledge" className={rootClasses.dangerousButton}>
+            <IconButton aria-label="acknowledge">
+              <CheckSharpIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Close" className={rootClasses.dangerousButton}>
+            <IconButton aria-label="close">
+              <CloseIcon />
+            </IconButton>
+          </Tooltip>
+        </>
+      ) : (
+        <Tooltip title="Filter list">
+          <IconButton aria-label="filter list">
+            <FilterListIcon />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Toolbar>
   );
 };
 
-type EventListItemPropsType = {
-  event: Event;
-};
-
-const EventListItem: React.FC<EventListItemPropsType> = ({ event }: EventListItemPropsType) => {
-  return (
-    <ListItem>
-      <ListItemText primary="Name" secondary={event.type.display} />
-    </ListItem>
-  );
-};
-
-type Tag = {
-  key: string;
-  value: string;
-};
-
-type TagChipPropsType = {
-  tag: Tag;
-};
-
-const isValidUrl = (url: string) => {
-  // Pavlo's answer at
-  // https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
-  try {
-    new URL(url);
-  } catch (_) {
-    return false;
+function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
+  if (b[orderBy] < a[orderBy]) {
+    return -1;
   }
-  return true;
-};
-
-const TagChip: React.FC<TagChipPropsType> = ({ tag }: TagChipPropsType) => {
-  if (isValidUrl(tag.value)) {
-    return <Chip label={`${tag.key}=${tag.value}`} component="a" href={tag.value} clickable />;
+  if (b[orderBy] > a[orderBy]) {
+    return 1;
   }
-  return <Chip label={`${tag.key}=${tag.value}`} />;
-};
+  return 0;
+}
 
-type TicketModifiableFieldPropsType = {
-  url?: string;
-  saveChange: (newUrl?: string) => void;
-};
+// TODO: refactor
+type Order = "asc" | "desc";
 
-const TicketModifiableField: React.FC<TicketModifiableFieldPropsType> = ({
-  url: urlProp,
-  saveChange,
-}: TicketModifiableFieldPropsType) => {
-  const classes = useStyles();
+function getComparator<T extends { [key: string]: number | string }>(
+  order: Order,
+  orderBy: keyof T,
+): (a: T, b: T) => number {
+  return order === "desc"
+    ? (a, b) => descendingComparator(a, b, orderBy)
+    : (a, b) => -descendingComparator(a, b, orderBy);
+}
 
-  const [changeUrl, setChangeUrl] = useState<boolean>(false);
-  const [url, setUrl] = useStateWithDynamicDefault<string | undefined>(urlProp);
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setUrl(event.target.value);
-    setChangeUrl(true);
-  };
-
-  const handleSave = () => {
-    // If url is empty string ("") store it as undefined.
-    if (url !== undefined && changeUrl) saveChange(url || undefined);
-    setChangeUrl(false);
-  };
-
-  const error = useMemo(() => !isValidUrl(url || ""), [url]);
-
-  return (
-    <ListItem>
-      <Grid container direction="row" justify="space-between">
-        <TextField
-          label="Ticket"
-          defaultValue={url || ""}
-          InputProps={{
-            readOnly: !changeUrl,
-          }}
-          onChange={handleChange}
-          error={error}
-          helperText={error && "Invalid URL"}
-        />
-        {(!changeUrl && (
-          <Button endIcon={<EditIcon />} onClick={() => setChangeUrl(true)}>
-            Edit
-          </Button>
-        )) || (
-          <Button className={classes.safeButton} onClick={() => handleSave()} disabled={error}>
-            Set ticket URL
-          </Button>
-        )}
-      </Grid>
-    </ListItem>
-  );
-};
-
-type SignedMessagePropsType = {
-  message: string;
-  user: number;
-  timestamp: Timestamp;
-
-  content?: React.ReactNode;
-  TextComponent?: React.ComponentType;
-};
-
-const SignedMessage: React.FC<SignedMessagePropsType> = ({
-  message,
-  user,
-  timestamp,
-  content,
-  TextComponent,
-}: SignedMessagePropsType) => {
-  const ackDate = new Date(timestamp);
-  const formattedAckDate = ackDate.toLocaleString();
-
-  const Component: React.ComponentType = TextComponent || ListItemText;
-
-  return (
-    <Grid container direction="column" spacing={2}>
-      {content || <Component>{message}</Component>}
-
-      <Grid container direction="row" spacing={2}>
-        <Grid item sm>
-          // TODO: get username / first+last name using `api.getUser(userPK)`
-          <Component>User with PK {user}</Component>
-        </Grid>
-        <Grid item container sm alignItems="flex-end" justify="space-evenly">
-          <Component>{formattedAckDate}</Component>
-        </Grid>
-      </Grid>
-    </Grid>
-  );
-};
-
-type AckListItemPropsType = {
-  ack: Acknowledgement;
-};
-
-const AckListItem: React.FC<AckListItemPropsType> = ({ ack }: AckListItemPropsType) => {
-  const classes = useStyles();
-
-  const ackDate = new Date(ack.event.timestamp);
-  const formattedAckDate = ackDate.toLocaleString();
-
-  let hasExpired = false;
-  let expiresMessage;
-  if (ack.expiration) {
-    const date = new Date(ack.expiration);
-    if (Date.parse(ack.expiration) < Date.now()) {
-      expiresMessage = `Expired ${date.toLocaleString()}`;
-      hasExpired = true;
-    } else {
-      expiresMessage = `Expires ${date.toLocaleString()}`;
-    }
-  }
-
-  return (
-    <div className={classes.message}>
-      <SignedMessage
-        message={ack.event.description}
-        timestamp={formattedAckDate}
-        user={ack.event.actor}
-        content={
-          <ListItemText
-            primary={expiresMessage || ""}
-            secondary={
-              <Typography paragraph style={{ textDecoration: hasExpired ? "line-through" : "none" }}>
-                {ack.event.description}
-              </Typography>
-            }
-          />
-        }
-      />
-    </div>
-  );
-};
-
-type OpenItemPropsType = {
-  open: boolean;
-};
-
-const OpenItem: React.FC<OpenItemPropsType> = ({ open }: OpenItemPropsType) => {
-  const classes = useStyles();
-  return (
-    <Chip variant="outlined" className={open ? classes.open : classes.closed} label={open ? "Open" : "Closed"} />
-  );
-};
-
-type AckedItemPropsType = {
-  acked: boolean;
-  expiration?: Timestamp | null;
-};
-
-const AckedItem: React.FC<AckedItemPropsType> = ({ acked, expiration }: AckedItemPropsType) => {
-  const classes = useStyles();
-
-  const expiryDate = expiration && new Date(expiration);
-  return (
-    <Chip
-      className={acked ? classes.acknowledged : classes.unacknowledged}
-      label={acked ? (expiryDate ? `Acknowledged until ${expiryDate}` : "Acknowledged") : "Unacknowledged"}
-    />
-  );
-};
-
-type TicketItemPropsType = {
-  ticketUrl?: string;
-};
-
-const TicketItem: React.FC<TicketItemPropsType> = ({ ticketUrl }: TicketItemPropsType) => {
-  const classes = useStyles();
-
-  const chipProps =
-    (ticketUrl && {
-      component: "a",
-      href: ticketUrl,
-      clickable: true,
-    }) ||
-    {};
-
-  return (
-    <Chip
-      variant="outlined"
-      className={ticketUrl ? classes.ticketed : classes.notticketed}
-      label={ticketUrl ? `Ticket ${ticketUrl}` : "No ticket"}
-      {...chipProps}
-    />
-  );
-};
-
-type SignOffActionPropsType = {
-  dialogTitle: string;
-  dialogContentText: string;
-  dialogCancelText: string;
-  dialogSubmitText: string;
-  dialogButtonText: string;
-  title: string;
-  question: string;
-  confirmName?: string;
-  rejectName?: string;
-  onSubmit: (msg: string) => void;
-  children?: React.Props<{}>["children"];
-};
-
-const SignOffAction: React.FC<SignOffActionPropsType> = ({
-  dialogTitle,
-  dialogContentText,
-  dialogCancelText,
-  dialogSubmitText,
-  dialogButtonText,
-  title,
-  question,
-  confirmName,
-  rejectName,
-  onSubmit,
-  children,
-}: SignOffActionPropsType) => {
-  const classes = useStyles();
-
-  const [open, setOpen] = useState<boolean>(false);
-  const [message, setMessage] = useState<string | undefined>(undefined);
-
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
-
-  const onConfirm = () => {
-    handleClose();
-    if (message) onSubmit(message);
-  };
-
-  const handleMessageChange = (e: React.ChangeEvent<HTMLInputElement>) => setMessage(e.target.value);
-
-  const CloseButton = makeConfirmationButton({
-    title,
-    question,
-    confirmName,
-    rejectName,
-    onConfirm,
+function stableSort<T>(array: T[], comparator: (a: T, b: T) => number) {
+  const stabilizedThis = array.map((el, index) => [el, index] as [T, number]);
+  stabilizedThis.sort((a, b) => {
+    const order = comparator(a[0], b[0]);
+    if (order !== 0) return order;
+    return a[1] - b[1];
   });
+  return stabilizedThis.map((el) => el[0]);
+}
 
-  return (
-    <div>
-      <Button onClick={handleOpen} className={classes.dangerousButton}>
-        {dialogButtonText}
-      </Button>
-      <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>{dialogTitle}</DialogTitle>
-        <DialogContent>
-          <DialogContentText>{dialogContentText}</DialogContentText>
-          <TextField
-            autoFocus
-            margin="dense"
-            id="messsage"
-            label="Messsage"
-            type="text"
-            fullWidth
-            value={message || ""}
-            onChange={handleMessageChange}
-          />
-          {children}
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose} className={classes.safeButton}>
-            {dialogCancelText}
-          </Button>
-          <CloseButton onClick={onConfirm} variant="contained" className={classes.dangerousButton}>
-            {dialogSubmitText}
-          </CloseButton>
-        </DialogActions>
-      </Dialog>
-    </div>
-  );
+type MUIIncidentTablePropsType = {
+  incidents: Incident[];
+  onShowDetail: (incide: Incident) => void;
 };
 
-type ManualClosePropsType = {
-  open: boolean;
-  onManualClose: (msg: string) => void;
-  onManualOpen: () => void;
-};
-
-const ManualClose: React.FC<ManualClosePropsType> = ({ open, onManualClose, onManualOpen }: ManualClosePropsType) => {
+const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
+  incidents,
+  onShowDetail,
+}: MUIIncidentTablePropsType) => {
   const classes = useStyles();
+  type SelectionState = "SelectedAll" | Set<Incident["pk"]>;
+  const [selectedIncidents, setSelectedIncidents] = useState<SelectionState>(new Set<Incident["pk"]>([]));
 
-  if (open) {
-    return (
-      <SignOffAction
-        dialogTitle="Manually close incident"
-        dialogContentText="Write a message describing why the incident was manually closed"
-        dialogSubmitText="Close now"
-        dialogCancelText="Cancel"
-        dialogButtonText="Close incident"
-        title="Manually close incident"
-        question="Are you sure you want to close this incident?"
-        onSubmit={onManualClose}
-      />
-    );
-  } else {
-    const ReopenButton = makeConfirmationButton({
-      title: "Reopen incident",
-      question: "Are you sure you want to reopen this incident?",
-      onConfirm: onManualOpen,
-    });
+  const [rowsPerPage, setRowsPerPage] = useState<number>(25);
+  const [page, setPage] = useState<number>(0);
 
-    return (
-      <ReopenButton variant="contained" className={classes.dangerousButton}>
-        Reopen incident
-      </ReopenButton>
-    );
-  }
-};
+  type IncidentOrderableFields = Pick<Incident, "start_time">;
 
-type CreateAckPropsType = {
-  onSubmitAck: (ack: AcknowledgementBody) => void;
-};
+  // TODO: implement proper ordering/sorting when support
+  // for this is implemented in the backend.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [order, setOrder] = React.useState<Order>("desc");
+  // TODO: fix typing problems here without use of any
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [orderBy, setOrderBy] = React.useState<keyof IncidentOrderableFields>("start_time");
 
-const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck }: CreateAckPropsType) => {
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const resetSelectedIncidents = () => {
+    setSelectedIncidents(new Set<Incident["pk"]>());
+  };
 
-  const handleSubmit = (msg: string) => {
-    // TODO: switch to use API when implemented in backend
-    onSubmitAck({
-      event: {
-        description: msg,
-      },
-      expiration: selectedDate && selectedDate.toUTCString(),
+  const handleChangePage = (event: unknown, page: number) => {
+    setPage(page);
+    resetSelectedIncidents();
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value));
+    setPage(0);
+    resetSelectedIncidents();
+  };
+
+  const handleRowClick = (event: React.MouseEvent<unknown>, incident: Incident) => {
+    onShowDetail(incident);
+  };
+
+  const handleToggleSelectAll = () => {
+    setSelectedIncidents((oldSelectedIncidents: SelectionState) => {
+      if (oldSelectedIncidents === "SelectedAll") {
+        return new Set<Incident["pk"]>([]);
+      }
+      return "SelectedAll";
     });
   };
 
-  const handleDateChange = (date: Date | null) => {
-    setSelectedDate(date);
+  const handleSelectIncident = (incident: Incident) => {
+    setSelectedIncidents((oldSelectedIncidents: SelectionState) => {
+      if (oldSelectedIncidents === "SelectedAll") {
+        const newSelected = new Set<Incident["pk"]>([...incidents.map((incident: Incident) => incident.pk)]);
+        newSelected.delete(incident.pk);
+        return newSelected;
+      }
+      const newSelectedIncidents = new Set<Incident["pk"]>(oldSelectedIncidents);
+      if (oldSelectedIncidents.has(incident.pk)) {
+        newSelectedIncidents.delete(incident.pk);
+      } else {
+        newSelectedIncidents.add(incident.pk);
+      }
+      return newSelectedIncidents;
+    });
   };
 
   return (
-    <SignOffAction
-      dialogTitle="Submit acknowledment"
-      dialogContentText="Write a message describing why this incident was acknowledged "
-      dialogSubmitText="Submit"
-      dialogCancelText="Cancel"
-      dialogButtonText="Create acknowledegment"
-      title="Submit acknowledment"
-      question="Are you sure you want to acknowledge this incident?"
-      onSubmit={handleSubmit}
-    >
-      <MuiPickersUtilsProvider utils={DateFnsUtils}>
-        <KeyboardDatePicker
-          disableToolbar
-          format="MM/dd/yyyy"
-          margin="normal"
-          id="expiry-date"
-          label="Expiry date"
-          value={selectedDate}
-          onChange={handleDateChange}
-          KeyboardButtonProps={{
-            "aria-label": "change date",
-          }}
-        />
-      </MuiPickersUtilsProvider>
-    </SignOffAction>
-  );
-};
+    <Paper>
+      <TableToolbar selectedIncidents={selectedIncidents} />
+      <TableContainer component={Paper}>
+        <MuiTable size="small" aria-label="incident table">
+          <TableHead>
+            <TableRow>
+              <TableCell padding="checkbox" onClick={() => handleToggleSelectAll()}>
+                <Checkbox checked={selectedIncidents === "SelectedAll"} />
+              </TableCell>
+              <TableCell>Id</TableCell>
+              <TableCell>Timestamp</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Source</TableCell>
+              <TableCell>Details</TableCell>
+              <TableCell>Description</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {stableSort<Incident>(incidents, getComparator<IncidentOrderableFields>(order, orderBy))
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map((incident: Incident) => {
+                const ClickableCell = (props: TableCellProps) => (
+                  <TableCell onClick={(event) => handleRowClick(event, incident)} {...props} />
+                );
 
-type IncidentDetailPropsType = {
-  incident?: Incident;
-  onIncidentChange: (incident: Incident) => void;
-};
+                const isSelected = selectedIncidents === "SelectedAll" || selectedIncidents.has(incident.pk);
 
-const IncidentDetail: React.FC<IncidentDetailPropsType> = ({ incident, onIncidentChange }: IncidentDetailPropsType) => {
-  const classes = useStyles();
-
-  // const [ticketUrl, setTicketUrl] = useState<string | undefined>(incident && incident.ticket_url);
-  // const [open, setOpen] = useState<boolean>((incident && incident.open) || false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { incidentSnackbar, displayAlertSnackbar }: UseAlertSnackbarResultType = useAlertSnackbar();
-  // TODO: handle close message
-
-  const defaultEvent1 = {
-    pk: 1,
-    incident: 1,
-    actor: 2,
-    timestamp: "2020-01-14T03:04:14.387000+01:00",
-    type: {
-      value: EventType.ACKNOWLEDGE,
-      display: "Acknowledge",
-    },
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vulputate id erat non pretium.",
-  };
-  const defaultEvent2 = {
-    pk: 2,
-    incident: 1,
-    actor: 1,
-    timestamp: "2020-01-15T03:04:14.387000+01:00",
-    type: {
-      value: EventType.ACKNOWLEDGE,
-      display: "Acknowledge",
-    },
-    description: "Ack ack",
-  };
-
-  const defaultAcks = [
-    {
-      pk: 1,
-      event: defaultEvent1,
-      expiration: "2020-02-14T15:04:14.387000+01:00",
-    },
-    {
-      pk: 2,
-      event: defaultEvent2,
-      expiration: null,
-    },
-  ];
-
-  const [acks, setAcks] = useState<Acknowledgement[]>(defaultAcks);
-
-  const chronoAcks = useMemo<Acknowledgement[]>(() => {
-    return [...acks].sort((first: Acknowledgement, second: Acknowledgement) => {
-      const firstTime = Date.parse(first.event.timestamp);
-      const secondTime = Date.parse(second.event.timestamp);
-      if (firstTime < secondTime) {
-        return 1;
-      } else if (firstTime > secondTime) {
-        return -1;
-      }
-      if (first.expiration && second.expiration) {
-        const firstExpires = Date.parse(first.expiration);
-        const secondExpires = Date.parse(second.expiration);
-        return firstExpires < secondExpires ? 1 : firstExpires > secondExpires ? -1 : 0;
-      }
-      return first.expiration ? 1 : -1;
-    });
-  }, [acks]);
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleManualClose = (msg: string) => {
-    if (!incident) return;
-    api // eslint-disable-next-line @typescript-eslint/camelcase
-      .postIncidentCloseEvent(incident.pk)
-      .then((event: Event) => {
-        displayAlertSnackbar(`Closed incident ${incident && incident.pk}`, "success");
-        onIncidentChange(incident);
-      })
-      .catch((error) => {
-        displayAlertSnackbar(`Failed to close incident ${incident && incident.pk} - ${error}`, "error");
-      });
-  };
-
-  const handleManualOpen = () => {
-    if (!incident) return;
-    api // eslint-disable-next-line @typescript-eslint/camelcase
-      .postIncidentReopenEvent(incident.pk)
-      .then((event: Event) => {
-        displayAlertSnackbar(`Reopened incident ${incident && incident.pk}`, "success");
-        onIncidentChange(incident);
-      })
-      .catch((error) => {
-        displayAlertSnackbar(`Failed to reopen incident ${incident && incident.pk} - ${error}`, "error");
-      });
-  };
-
-  if (!incident) return <h1>none</h1>;
-
-  const ackExpiryDate = undefined;
-
-  const tags = [
-    { key: "test_url", value: "https://uninett.no" },
-    { key: "test_host", value: "uninett.no" },
-    { key: "host", value: "uninett.no" },
-    { key: "timestamp", value: "123123123" },
-    { key: "bytes", value: "askldfjalskdf" },
-    { key: "origin_src", value: "something.tst" },
-  ];
-
-  return (
-    <div className={classes.root}>
-      {incidentSnackbar}
-      <Grid container spacing={3} className={classes.grid}>
-        <Grid container item spacing={2} md alignItems="stretch" justify="space-evenly" direction="column">
-          <Grid item>
-            <Card>
-              <CardContent>
-                <Typography color="textSecondary" gutterBottom>
-                  Status
-                </Typography>
-                <CenterContainer>
-                  <OpenItem open={incident.open} />
-                  <AckedItem acked={true} expiration={ackExpiryDate} />
-                  <TicketItem ticketUrl={incident.ticket_url} />
-                </CenterContainer>
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {!incident.open && (
-            <Grid item>
-              <Card>
-                <CardContent>
-                  <Typography color="textSecondary" gutterBottom>
-                    Incident closed
-                  </Typography>
-                  <SignedMessage
-                    message={"Incident was resolved on servicerestart"}
-                    content={<Typography paragraph>Incident was resolved on servicerestart</Typography>}
-                    timestamp={new Date().toUTCString()}
-                    user={1}
-                    TextComponent={Typography}
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
-          )}
-
-          <Grid item>
-            <Card>
-              <CardContent>
-                <Typography color="textSecondary" gutterBottom>
-                  Tags
-                </Typography>
-                {tags.map((tag: Tag) => (
-                  <TagChip key={tag.key} tag={tag} />
-                ))}
-              </CardContent>
-            </Card>
-          </Grid>
-
-          <Grid item>
-            <Card>
-              <CardContent>
-                <Typography color="textSecondary" gutterBottom>
-                  Primary details
-                </Typography>
-                <List>
-                  <IncidentDetailListItem title="Description" detail={incident.description} />
-                  <IncidentDetailListItem title="Timestamp" detail={incident.timestamp} />
-                  <IncidentDetailListItem title="Source" detail={incident.source.name} />
-                  <IncidentDetailListItem
-                    title="Details URL"
-                    detail={<a href={incident.details_url}>{incident.details_url}</a>}
-                  />
-
-                  <TicketModifiableField
-                    url={incident.ticket_url}
-                    saveChange={(url?: string) => {
-                      // TODO: api
-                      api
-                        .patchIncidentTicketUrl(incident.pk, url || "")
-                        .then((incident: Incident) => {
-                          displayAlertSnackbar(`Updated ticket URL for ${incident && incident.pk}`, "success");
-                          onIncidentChange(incident);
-                        })
-                        .catch((error) => {
-                          displayAlertSnackbar(`Failed to updated ticket URL ${error}`, "error");
-                        });
+                return (
+                  <TableRow
+                    hover
+                    key={incident.pk}
+                    selected={isSelected}
+                    style={{
+                      cursor: "pointer",
                     }}
-                  />
-                  <ListItem>
-                    <CenterContainer>
-                      <ManualClose
-                        open={incident.open}
-                        onManualClose={handleManualClose}
-                        onManualOpen={handleManualOpen}
-                      />
-                    </CenterContainer>
-                  </ListItem>
-                </List>
-              </CardContent>
-            </Card>
-          </Grid>
-        </Grid>
-
-        <Grid container item spacing={2} md direction="column">
-          <Grid item>
-            <Typography color="textSecondary" gutterBottom>
-              Acknowledgements
-            </Typography>
-            <List>
-              {chronoAcks.map((ack: Acknowledgement) => (
-                <AckListItem key={ack.event.timestamp} ack={ack} />
-              ))}
-            </List>
-            <CenterContainer>
-              <CreateAck
-                key={acks.length}
-                onSubmitAck={(ack: AcknowledgementBody) => {
-                  // TODO: handle ack submit here
-                  console.log(ack);
-                  api
-                    .postAck(incident.pk, ack)
-                    .then((ack: Acknowledgement) => {
-                      displayAlertSnackbar(`Submitted ack for ${incident && incident.pk}`, "success");
-                      setAcks([...acks, ack]);
-                    })
-                    .catch((error) => {
-                      displayAlertSnackbar(`Failed to post ack ${error}`, "error");
-                    });
-                }}
-              />
-            </CenterContainer>
-          </Grid>
-          <Grid item>
-            <Card>
-              <CardContent>
-                <Typography color="textSecondary" gutterBottom>
-                  Related events
-                </Typography>
-                <List>
-                  <EventListItem event={defaultEvent1} />
-                  <EventListItem event={defaultEvent2} />
-                </List>
-              </CardContent>
-            </Card>
-          </Grid>
-        </Grid>
-      </Grid>
-    </div>
+                  >
+                    <TableCell padding="checkbox" onClick={() => handleSelectIncident(incident)}>
+                      <Checkbox checked={isSelected} />
+                    </TableCell>
+                    <ClickableCell>{incident.pk}</ClickableCell>
+                    <ClickableCell>{new Date(incident.start_time).toLocaleString()}</ClickableCell>
+                    <ClickableCell component="th" scope="row">
+                      <OpenItem small open={incident.open} />
+                      <TicketItem small ticketUrl={incident.ticket_url} />
+                      <AckedItem small acked />
+                    </ClickableCell>
+                    <ClickableCell>{incident.source.name}</ClickableCell>
+                    <ClickableCell>{<a href={incident.details_url}>{incident.details_url}</a>}</ClickableCell>
+                    <ClickableCell>{incident.description}</ClickableCell>
+                    <TableCell>
+                      <Button className={classes.safeButton} onClick={() => onShowDetail(incident)}>
+                        Details
+                      </Button>
+                      {true && (
+                        <Button className={classes.safeButton} href="https://localhost.com">
+                          Ticket
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+          </TableBody>
+        </MuiTable>
+      </TableContainer>
+      <TablePagination
+        rowsPerPageOptions={[10, 25, 50, 100]}
+        component="div"
+        count={incidents.length}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onChangePage={handleChangePage}
+        onChangeRowsPerPage={handleChangeRowsPerPage}
+      />
+    </Paper>
   );
 };
+
+type Revisioned<T> = T & { revision?: number };
 
 type IncidentsProps = {
   incidents: Incident[];
   noDataText: string;
+  realtime?: boolean;
+  active?: boolean;
 };
 
-const SourceDetailUrl = (row: { value: string; original: { details_url: string } }) => {
-  return (
-    <a href={row.original.details_url} rel="noopener noreferrer" target="_blank">
-      {" "}
-      {row.value}{" "}
-    </a>
-  );
-};
-
-const IncidentTable: React.FC<IncidentsProps> = ({ incidents }: IncidentsProps) => {
+const IncidentTable: React.FC<IncidentsProps> = ({ incidents, realtime, active }: IncidentsProps) => {
   const [incidentForDetail, setIncidentForDetail] = useState<Incident | undefined>(undefined);
 
-  const incidentsDictFromProps = useMemo<Map<Incident["pk"], Incident>>(
+  const incidentsDictFromProps = useMemo<Revisioned<Map<Incident["pk"], Incident>>>(
     () => toMap<Incident["pk"], Incident>(incidents, pkGetter),
     [incidents],
   );
 
-  const [incidentsDict, setIncidentsDict] = useStateWithDynamicDefault<Map<Incident["pk"], Incident>>(
+  const [incidentsDict, setIncidentsDict] = useStateWithDynamicDefault<Revisioned<Map<Incident["pk"], Incident>>>(
     incidentsDictFromProps,
   );
 
-  const timestampCellWidth: ConstraintFunction<Incident> = () =>
-    calculateTableCellWidth("2015-11-14T03:04:14.387000+01:00");
+  const [incidentsUpdated, setIncidentsUpdated] = useState<Revisioned<Incident[]>>(incidents);
+  const { incidentSnackbar, displayAlertSnackbar }: UseAlertSnackbarResultType = useAlertSnackbar();
 
-  const showDetail = (incident: Incident) => {
+  useEffect(() => {
+    console.log("updating incidents");
+    setIncidentsUpdated([...incidentsDict.values()]);
+  }, [incidentsDict]);
+
+  const handleShowDetail = (incident: Incident) => {
     setIncidentForDetail(incident);
   };
-
-  const detailsAccessor: Accessor<Incident> = (row: Incident) => {
-    return (
-      <Button variant="contained" onClick={() => showDetail(row)}>
-        Details
-      </Button>
-    );
-  };
-
-  const columns = [
-    {
-      id: "timestamp_col",
-      ...maxWidthColumn<Incident>(incidents, "Timestamp", "timestamp", timestampCellWidth),
-    },
-    {
-      id: "source_col",
-      Cell: SourceDetailUrl,
-      ...maxWidthColumn<Incident>(
-        incidents,
-        "Source",
-        (incident: Incident) => String(incident.source.name),
-        getMaxColumnWidth,
-      ),
-    },
-    // {
-    //   id: "problem_type_col",
-    //   ...maxWidthColumn<A>(incidents, "Problem type", "problem_type.name", getMaxColumnWidth),
-    // },
-    // {
-    //   id: "object_col",
-    //   ...maxWidthColumn<A>(incidents, "Object", "object.name", getMaxColumnWidth),
-    // },
-    // {
-    //   id: "parent_object_col",
-    //   ...maxWidthColumn<A>(incidents, "Parent object", "parent_object.name", getMaxColumnWidth),
-    // },
-    {
-      id: "description_col",
-      Header: "Description",
-      accessor: "description",
-    },
-    {
-      id: "details_col",
-      Header: "Details",
-      accessor: detailsAccessor,
-    },
-  ];
 
   const classes = useStyles();
 
@@ -870,8 +319,8 @@ const IncidentTable: React.FC<IncidentsProps> = ({ incidents }: IncidentsProps) 
   };
 
   const handleIncidentChange = (incident: Incident) => {
-    setIncidentsDict((oldDict: Map<Incident["pk"], Incident>) => {
-      const newDict = new Map<Incident["pk"], Incident>(oldDict);
+    setIncidentsDict((oldDict: Revisioned<Map<Incident["pk"], Incident>>) => {
+      const newDict: typeof oldDict = new Map<Incident["pk"], Incident>(oldDict);
       const oldIncident = oldDict.get(incident.pk);
       if (!oldIncident || incident.open != oldIncident.open) {
         if (!incident.open) {
@@ -885,10 +334,91 @@ const IncidentTable: React.FC<IncidentsProps> = ({ incidents }: IncidentsProps) 
         // updated in some other way
         newDict.set(incident.pk, incident);
       }
+      newDict.revision = (newDict.revision || 1) + 1;
+      //onsole.log("revision", newDict.revision);
       return newDict;
     });
-    setIncidentForDetail(incident);
+    if (incidentForDetail && incidentForDetail.pk === incident.pk) setIncidentForDetail(incident);
   };
+
+  // TODO: move this logic somewhere else
+  useEffect(() => {
+    if (!realtime) return;
+
+    const ws = new WebSocket(`${BACKEND_WS_URL}/active/`);
+    // cookies.set("token", token, { path: "/", secure: USE_SECURE_COOKIE });
+    console.log("websocket", ws);
+
+    const msg = {
+      action: "subscribe",
+    };
+    ws.onmessage = function (e) {
+      const data = JSON.parse(e.data);
+      console.log("onmessage", data);
+
+      switch (data.type) {
+        case "modified":
+          const modifiedIncident: Incident = data.payload;
+          handleIncidentChange(modifiedIncident);
+          break;
+        case "created":
+          console.log("Created", data);
+          const createdIncident: Incident = data.payload;
+
+          if (open && !createdIncident.open) {
+            // TODO: how to handle this?
+            break;
+          }
+
+          setIncidentsDict((oldDict: Revisioned<Map<Incident["pk"], Incident>>) => {
+            const newDict: typeof oldDict = new Map<Incident["pk"], Incident>(oldDict);
+            newDict.revision = (newDict.revision || 1) + 1;
+            newDict.set(createdIncident.pk, createdIncident);
+            return newDict;
+          });
+          break;
+
+        case "deleted":
+          console.log("Deleted", data);
+          const deletedIncident: Incident = data.payload;
+
+          setIncidentsDict((oldDict: Revisioned<Map<Incident["pk"], Incident>>) => {
+            const newDict: typeof oldDict = new Map<Incident["pk"], Incident>(oldDict);
+            newDict.revision = (newDict.revision || 1) + 1;
+            newDict.delete(deletedIncident.pk);
+            return newDict;
+          });
+          break;
+
+        case "subscribed":
+          const incidents: Incident[] = data.start_incidents;
+          setIncidentsDict((oldDict: Revisioned<Map<Incident["pk"], Incident>>) => {
+            const newDict: typeof oldDict = new Map<Incident["pk"], Incident>(oldDict);
+            newDict.revision = (newDict.revision || 1) + 1;
+            incidents.map((incident: Incident) => newDict.set(incident.pk, incident));
+            return newDict;
+          });
+          displayAlertSnackbar(`Subscribed for realtime updates`, "success");
+          break;
+
+        default:
+          displayAlertSnackbar(`Unhandled WebSockets message type: ${data.type}`, "warning");
+          break;
+      }
+    };
+
+    ws.onopen = () => {
+      console.log("onopen");
+      ws.send(JSON.stringify(msg));
+    };
+
+    ws.onclose = () => {
+      console.log("onclose");
+      ws.close();
+      displayAlertSnackbar(`Realtime updates disabled`, "success");
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <ClickAwayListener onClickAway={onModalClose}>
@@ -900,31 +430,36 @@ const IncidentTable: React.FC<IncidentsProps> = ({ incidents }: IncidentsProps) 
           aria-describedby="simple-modal-description"
           maxWidth={"lg"}
         >
-          <div>
-            <AppBar position="static">
-              <Toolbar variant="dense">
-                <IconButton
-                  edge="start"
-                  onClick={onModalClose}
-                  className={classes.closeIcon}
-                  color="inherit"
-                  aria-label="close"
-                >
-                  <CloseIcon />
-                </IconButton>
-                <Typography variant="h6" className={classes.title}>
-                  Incident Details
-                </Typography>
-              </Toolbar>
-            </AppBar>
-            <IncidentDetail
-              key={incidentForDetail?.pk}
-              onIncidentChange={handleIncidentChange}
-              incident={incidentForDetail}
-            />
-          </div>
+          {(incidentForDetail && (
+            <div>
+              <AppBar position="static">
+                <Toolbar variant="dense">
+                  <IconButton
+                    edge="start"
+                    onClick={onModalClose}
+                    className={classes.closeIcon}
+                    color="inherit"
+                    aria-label="close"
+                  >
+                    <CloseIcon />
+                  </IconButton>
+                  <Typography variant="h6" className={classes.title}>
+                    Incident {incidentForDetail.pk}
+                  </Typography>
+                </Toolbar>
+              </AppBar>
+              <IncidentDetails
+                key={incidentForDetail.pk}
+                onIncidentChange={handleIncidentChange}
+                incident={incidentForDetail}
+                displayAlertSnackbar={displayAlertSnackbar}
+              />
+            </div>
+          )) || <h1>Empty</h1>}
         </Dialog>
-        <Table data={[...incidentsDict.values()]} columns={columns} sorted={[{ id: "timestamp_col", desc: true }]} />
+        {realtime && <Typography>Realtime</Typography>}
+        <MUIIncidentTable incidents={incidentsUpdated} onShowDetail={handleShowDetail} />
+        {incidentSnackbar}
       </div>
     </ClickAwayListener>
   );

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -29,7 +29,7 @@ import { useStateWithDynamicDefault, toMap, pkGetter } from "../../utils";
 
 import { useAlertSnackbar, UseAlertSnackbarResultType } from "../../components/alertsnackbar";
 
-import api, { Incident, Event, EventType, Acknowledgement, AcknowledgementBody, Timestamp } from "../../api";
+import { Incident } from "../../api";
 import { BACKEND_WS_URL } from "../../config";
 import { useStyles } from "../incident/styles";
 import { AckedItem, OpenItem, TicketItem } from "../incident/Chips";
@@ -285,10 +285,10 @@ type IncidentsProps = {
   incidents: Incident[];
   noDataText: string;
   realtime?: boolean;
-  active?: boolean;
+  open?: boolean;
 };
 
-const IncidentTable: React.FC<IncidentsProps> = ({ incidents, realtime, active }: IncidentsProps) => {
+const IncidentTable: React.FC<IncidentsProps> = ({ incidents, realtime, open }: IncidentsProps) => {
   const [incidentForDetail, setIncidentForDetail] = useState<Incident | undefined>(undefined);
 
   const incidentsDictFromProps = useMemo<Revisioned<Map<Incident["pk"], Incident>>>(

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -1,3 +1,4 @@
-export const BACKEND_URL = "";
-export const USE_SECURE_COOKIE = true;
-export const DEBUG = true;
+export const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || "";
+export const BACKEND_WS_URL = process.env.REACT_APP_BACKEND_WS_URL || "";
+export const USE_SECURE_COOKIE = process.env.REACT_APP_USE_SECURE_COOKIE === "false" || true;
+export const DEBUG = process.env.REACT_APP_DEBUG === "true" || false;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -13,7 +13,7 @@ export interface IncidentWithFormattedTimestamp extends Incident {
 export function incidentWithFormattedTimestamp(incident: Incident): IncidentWithFormattedTimestamp {
   return {
     ...incident,
-    formattedTimestamp: moment(incident.timestamp).format("YYYY.MM.DD  hh:mm:ss"),
+    formattedTimestamp: moment(incident.start_time).format("YYYY.MM.DD  hh:mm:ss"),
   };
 }
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -20,7 +20,7 @@ export function incidentWithFormattedTimestamp(incident: Incident): IncidentWith
 export async function loginAndSetUser(token: Token): Promise<void> {
   return auth.login(token, () => {
     api
-      .authGetUser()
+      .authGetCurrentUser()
       .then((user: User) => {
         const userName: string = user.first_name.split(" ")[0];
         localStorage.setItem("user", userName);

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -15,7 +15,7 @@ const IncidentView: React.FC<IncidentViewPropsType> = () => {
   const [{ result: incidents, isLoading, isError }, setPromise] = useApiIncidents();
 
   useEffect(() => {
-    setPromise(api.getActiveIncidents());
+    setPromise(api.getOpenIncidents());
   }, [setPromise]);
 
   const noDataText = isLoading ? LOADING_TEXT : isError ? ERROR_TEXT : NO_DATA_TEXT;
@@ -25,7 +25,7 @@ const IncidentView: React.FC<IncidentViewPropsType> = () => {
       <header>
         <Header />
       </header>
-      <h1 className={"filterHeader"}>Active Incidents </h1>
+      <h1 className={"filterHeader"}>Open Incidents </h1>
       <div className="table">
         <IncidentTable incidents={incidents || []} noDataText={noDataText} />
       </div>

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -1,33 +1,247 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import "./IncidentView.css";
 import Header from "../../components/header/Header";
 import IncidentTable from "../../components/incidenttable/IncidentTable";
 import "../../components/incidenttable/incidenttable.css";
 import { withRouter } from "react-router-dom";
-import api from "../../api";
+
+import Checkbox from "@material-ui/core/Checkbox";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+
+import Grid from "@material-ui/core/Grid";
+
+import Typography from "@material-ui/core/Typography";
+import Select from "@material-ui/core/Select";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import TextField from "@material-ui/core/TextField";
+import MenuItem from "@material-ui/core/MenuItem";
+
+import api, { Incident } from "../../api";
 import { useApiIncidents } from "../../api/hooks";
 
 import { LOADING_TEXT, ERROR_TEXT, NO_DATA_TEXT } from "../../constants";
 
+type Tag = {
+  key: string;
+  value: string;
+};
+
+type SourceSelectorPropsType = {
+  sources: string[];
+  onSelectionChange: (source: string[]) => void;
+};
+
+const SourceSelector: React.FC<SourceSelectorPropsType> = ({ sources, onSelectionChange }: SourceSelectorPropsType) => {
+  return (
+    <Autocomplete
+      freeSolo
+      multiple
+      size="small"
+      id="filter-select-tags"
+      disableClearable
+      options={sources}
+      renderInput={(params) => (
+        <TextField {...params} variant="outlined" InputProps={{ ...params.InputProps, type: "search" }} />
+      )}
+      onChange={(e: unknown, changeValue, reason: string) => {
+        console.log("onChange", reason, changeValue);
+        switch (reason) {
+          default:
+            onSelectionChange(changeValue);
+            break;
+        }
+      }}
+    />
+  );
+};
+
+type TagSelectorPropsType = {
+  tags: Tag[];
+  onSelectionChange: (tags: Tag[]) => void;
+};
+
+const TagSelector: React.FC<TagSelectorPropsType> = ({ tags, onSelectionChange }: TagSelectorPropsType) => {
+  const [value, setValue] = useState<string>("");
+  const [selectValue, setSelectValue] = useState<string[]>([]);
+
+  // NOTE: proper handling of key-value pairs
+  // is probably needed.
+  const toTag = (str: string): Tag => {
+    const [key, value] = str.split("=", 2);
+    return { key, value };
+  };
+
+  const handleSelectNew = (newValue: string[]) => {
+    setSelectValue((oldValue: string[]) => {
+      const oldSet = new Set<string>(oldValue);
+
+      let updatedInputValue = false;
+      newValue
+        .filter((s: string) => !oldSet.has(s))
+        .map((s: string) => {
+          if (!updatedInputValue) {
+            updatedInputValue = true;
+            setValue(s);
+          }
+        });
+
+      return updatedInputValue ? oldValue : newValue;
+    });
+  };
+
+  useEffect(() => {
+    onSelectionChange(selectValue.map(toTag));
+  }, [selectValue, onSelectionChange]);
+
+  return (
+    <Autocomplete
+      freeSolo
+      multiple
+      size="small"
+      id="filter-select-tags"
+      disableClearable
+      options={tags.map((tag: Tag) => tag.key)}
+      onChange={(e: unknown, changeValue, reason: string) => {
+        console.log("onChange", reason, changeValue);
+        switch (reason) {
+          case "select-option":
+            handleSelectNew(changeValue);
+            break;
+
+          default:
+            setSelectValue(changeValue);
+            break;
+        }
+      }}
+      inputValue={value}
+      onInputChange={(e: unknown, inputValue: string, reason: string) => {
+        console.log("set value", reason, ":", inputValue);
+        setValue(inputValue);
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="outlined"
+          label={selectValue ? undefined : "Filter tags"}
+          InputProps={{ ...params.InputProps, type: "search" }}
+        />
+      )}
+      value={selectValue}
+    />
+  );
+};
+
 type IncidentViewPropsType = {};
 
-const IncidentView: React.FC<IncidentViewPropsType> = () => {
+const IncidentView: React.FC<IncidentViewPropsType> = ({}: IncidentViewPropsType) => {
+  const [realtime, setRealtime] = useState<boolean>(true);
+  const [tagsFilter, setTagsFilter] = useState<Tag[]>([]);
+  const [sources, setSources] = useState<Set<string> | "AllSources">("AllSources");
+  const [show, setShow] = useState<"open" | "closed" | "both">("open");
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [tags, setTags] = useState<Tag[]>([
+    { key: "url", value: "https://test.test" },
+    { key: "host", value: "localhost" },
+  ]);
+
   const [{ result: incidents, isLoading, isError }, setPromise] = useApiIncidents();
 
   useEffect(() => {
-    setPromise(api.getOpenIncidents());
-  }, [setPromise]);
+    if (show === "open") setPromise(api.getOpenIncidents());
+    else setPromise(api.getAllIncidents());
+  }, [setPromise, show]);
 
   const noDataText = isLoading ? LOADING_TEXT : isError ? ERROR_TEXT : NO_DATA_TEXT;
+
+  const filteredIncidents = useMemo<Incident[]>(() => {
+    // TODO: filtering on source for testing purposes.
+    const filterOnTags = (incident: Incident) => {
+      for (const tag of tagsFilter.filter((tag: Tag) => tag.key === "source")) {
+        if (incident.source.name === tag.value) {
+          return true;
+        }
+        return false;
+      }
+      return true;
+    };
+
+    const filterOnSources = (incident: Incident) => sources === "AllSources" || sources.has(incident.source.name);
+
+    // TODO: filtering on active should be done in the backend API
+    return (
+      (incidents &&
+        incidents
+          .filter((incident: Incident) => (show === "open" ? incident.open : show === "closed" ? !incident.open : true))
+          .filter(filterOnTags)
+          .filter(filterOnSources)) ||
+      []
+    );
+  }, [incidents, show, tagsFilter, sources]);
+
+  const sourceAlts = useMemo(
+    () => [...new Set([...(incidents || []).map((incident: Incident) => incident.source.name)]).values()],
+    [incidents],
+  );
+
+  const handleShowChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setShow(event.target.value as "open" | "closed" | "both");
+  };
 
   return (
     <div>
       <header>
         <Header />
       </header>
-      <h1 className={"filterHeader"}>Open Incidents </h1>
+      <h1 className={"filterHeader"}>Incidents</h1>
+      <Card>
+        <CardContent>
+          <Grid container xl direction="row" justify="space-evenly" alignItems="stretch">
+            <Grid item md>
+              <Typography>Show open/closed</Typography>
+              <Select variant="outlined" value={show} onChange={handleShowChange}>
+                <MenuItem value={"open"}>Open</MenuItem>
+                <MenuItem value={"closed"}>Closed</MenuItem>
+                <MenuItem value={"both"}>Both</MenuItem>
+              </Select>
+            </Grid>
+
+            <Grid item md>
+              <Typography>Realtime</Typography>
+              <Checkbox checked={realtime} onClick={() => setRealtime((old) => !old)} />
+            </Grid>
+            <Grid item md>
+              <Typography>Sources to display</Typography>
+              <SourceSelector
+                sources={sourceAlts}
+                onSelectionChange={(selection: string[]) => {
+                  console.log("source selection changed", selection);
+                  setSources((selection.length !== 0 && new Set<string>(selection)) || "AllSources");
+                }}
+              />
+            </Grid>
+
+            <Grid item md>
+              <Typography>Tags filter</Typography>
+              <TagSelector
+                tags={tags}
+                onSelectionChange={useCallback((selection: Tag[]) => {
+                  console.log("selection changed", selection);
+                  setTagsFilter(selection);
+                }, [])}
+              />
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
       <div className="table">
-        <IncidentTable incidents={incidents || []} noDataText={noDataText} />
+        <IncidentTable
+          realtime={realtime}
+          active={show === "open"}
+          incidents={filteredIncidents}
+          noDataText={noDataText}
+        />
       </div>
     </div>
   );

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -238,7 +238,7 @@ const IncidentView: React.FC<IncidentViewPropsType> = ({}: IncidentViewPropsType
       <div className="table">
         <IncidentTable
           realtime={realtime}
-          active={show === "open"}
+          open={show === "open"}
           incidents={filteredIncidents}
           noDataText={noDataText}
         />

--- a/src/views/login/LoginView.tsx
+++ b/src/views/login/LoginView.tsx
@@ -55,7 +55,7 @@ const LoginView: React.FC<LoginViewPropsType> = (props: LoginViewPropsType) => {
               <input
                 name={"username"}
                 value={username}
-                placeholder={"Email"}
+                placeholder={"Username"}
                 onChange={(e) => setUsername(e.target.value)}
               />
             </div>


### PR DESCRIPTION
This PR achieves the following:
- Replace list/table component for active/open incidents with one from material ui
- Updates to work with latest master branch of backend (Uninett/Argus 137193932913d103fba6e0ded982702bf4a1b12d)

Incident overview features:
- [X] Filtering by tags (tough not implemented in backend yet)
- [X] Filtering by sources
- [X] Selecting to show only open or closed, or both (incidents)
- [X] Selectable rows 
- [ ] Actions on selected rows (link together, multi close, multi ack, ...)
- [X] Clickable details URL
- [X] Click on dedicated details button, or press anywhere otherwise non-clickable to open details modal
- [X] Pagination based on loaded data
- [ ] Pagination based on fetchable data (requires support in REST API)
- [X] Code is built to support ordering by arbitrary fields and sorting on them 
- [ ] Select sort direction and fields in UI
- [X] Status Chips that display "open"/"closed", "ticket" (with clickable link)/"no ticket" and "acked"/"not acked".
- [X] When realtime support is enabled it will automatically re-render with those changes