### PR TITLE
Display events, acknowledgements and tags & proper filtering based on tags

### DIFF
--- a/src/api/hooks.tsx
+++ b/src/api/hooks.tsx
@@ -3,11 +3,13 @@ import { Incident } from ".";
 // TODO: fix this
 import { incidentWithFormattedTimestamp, IncidentWithFormattedTimestamp } from "../utils";
 import {
+  Acknowledgement,
   ApiErrorType,
-  NotificationProfile,
-  NotificationProfilePK,
+  Event,
   Filter,
   FilterPK,
+  NotificationProfile,
+  NotificationProfilePK,
   Timeslot,
   TimeslotPK,
 } from "../api";
@@ -76,3 +78,13 @@ export const useApiFilters = (onResult?: (result: Map<FilterPK, Filter>) => void
 
 export const useApiTimeslots = (onResult?: (result: Map<TimeslotPK, Timeslot>) => void) =>
   createUsePromise<Timeslot[], Map<TimeslotPK, Timeslot>>(asMap, onResult);
+
+export const useApiIncidentAcks = createUsePromise<Acknowledgement[], Acknowledgement[]>(
+  (acks: Acknowledgement[]) => acks,
+  () => undefined,
+);
+
+export const useApiIncidentEvents = createUsePromise<Event[], Event[]>(
+  (events: Event[]) => events,
+  () => undefined,
+);

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -127,12 +127,17 @@ export interface IncidentProblemType {
   url: string;
 }
 
+export interface IncidentTag {
+  added_by: number;
+  added_time: Timestamp;
+  tag: string;
+}
+
 export interface Incident {
   pk: number;
   start_time: string;
   end_time?: string;
   stateful: boolean;
-  incident_id: string;
   details_url: string;
   description: string;
   ticket_url: string;
@@ -140,9 +145,9 @@ export interface Incident {
   acked: boolean;
 
   source: SourceSystem;
-  object: IncidentObject;
-  parent_object: IncidentObject;
-  problem_type: IncidentProblemType;
+  source_incident_id: string;
+
+  tags: IncidentTag[];
 }
 
 export enum EventType {

--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -223,7 +223,7 @@ const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck }: CreateAckProps
       event: {
         description: msg,
       },
-      expiration: selectedDate && selectedDate.toUTCString(),
+      expiration: selectedDate && selectedDate.toISOString(),
     });
   };
 

--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -503,9 +503,10 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
                         `Submitted ${ack.event.type.display} for ${incident && incident.pk}`,
                         "success",
                       );
-                      // force reload everything
-                      setAcksPromise(api.getIncidentAcks(incident.pk));
-                      setEventsPromise(api.getIncidentEvents(incident.pk));
+                      // NOTE: this assumes that nothing about the incident
+                      // changes in the backend response other than the acked
+                      // field, which may not be true in the future.
+                      onIncidentChange({ ...incident, acked: true });
                     })
                     .catch((error) => {
                       displayAlertSnackbar(`Failed to post ack ${error}`, "error");

--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 // import "./incidenttable.css";
 import "react-table/react-table.css";
 
@@ -21,13 +21,16 @@ import Typography from "@material-ui/core/Typography";
 import DateFnsUtils from "@date-io/date-fns";
 import { MuiPickersUtilsProvider, KeyboardDatePicker } from "@material-ui/pickers";
 
+import Skeleton from "@material-ui/lab/Skeleton";
+
 import { useStateWithDynamicDefault } from "../../utils";
 
 import { makeConfirmationButton } from "../../components/buttons/ConfirmationButton";
 import { UseAlertSnackbarResultType } from "../../components/alertsnackbar";
 import CenterContainer from "../../components/centercontainer";
 
-import api, { Event, EventType, Incident, Acknowledgement, AcknowledgementBody } from "../../api";
+import api, { Event, EventType, Incident, IncidentTag, Acknowledgement, AcknowledgementBody } from "../../api";
+import { useApiIncidentAcks, useApiIncidentEvents } from "../../api/hooks";
 
 import SignedMessage from "./SignedMessage";
 import SignOffAction from "./SignOffAction";
@@ -56,10 +59,21 @@ type EventListItemPropsType = {
 };
 
 const EventListItem: React.FC<EventListItemPropsType> = ({ event }: EventListItemPropsType) => {
+  const classes = useStyles();
   return (
-    <ListItem>
-      <ListItemText primary="Name" secondary={event.type.display} />
-    </ListItem>
+    <div className={classes.message}>
+      <SignedMessage
+        message={event.description}
+        timestamp={event.timestamp}
+        user={event.actor}
+        content={
+          <ListItemText
+            primary={event.type.display}
+            secondary={<Typography paragraph>{event.description}</Typography>}
+          />
+        }
+      />
+    </div>
   );
 };
 
@@ -296,61 +310,16 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
 }: IncidentDetailsPropsType) => {
   const classes = useStyles();
 
-  // const [ticketUrl, setTicketUrl] = useState<string | undefined>(incident && incident.ticket_url);
-  // const [active, setActive] = useState<boolean>((incident && incident.active) || false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  //onst { incidentSnackbar, displayAlertSnackbar }: UseAlertSnackbarResultType = useAlertSnackbar();
-  // TODO: handle close message
+  const [{ result: acks, isLoading: isAcksLoading }, setAcksPromise] = useApiIncidentAcks();
+  const [{ result: events, isLoading: isEventsLoading }, setEventsPromise] = useApiIncidentEvents();
 
-  // TODO: users should be represented by username...
-  const defaultEvent1 = {
-    pk: 1,
-    incident: 1,
-    actor: 2,
-    timestamp: "2020-01-14T03:04:14.387000+01:00",
-    type: {
-      value: EventType.ACKNOWLEDGE,
-      display: "Acknowledge",
-    },
-    description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vulputate id erat non pretium.",
-  };
-  const defaultEvent2 = {
-    pk: 2,
-    incident: 1,
-    actor: 1,
-    timestamp: "2020-01-15T03:04:14.387000+01:00",
-    type: {
-      value: EventType.ACKNOWLEDGE,
-      display: "Acknowledge",
-    },
-    description: "Ack ack",
-  };
-
-  const defaultAcks = [
-    {
-      user: "testuser2",
-      timestamp: "2020-01-14T03:04:14.387000+01:00",
-      message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vulputate id erat non pretium.",
-      expiresAt: "2020-02-14T03:04:14.387000+01:00",
-      pk: 1,
-      event: defaultEvent1,
-      expiration: "2020-02-14T15:04:14.387000+01:00",
-    },
-    {
-      user: "testuser",
-      timestamp: "2020-01-15T03:04:14.387000+01:00",
-      message: "Ack ack",
-      expiresAt: null,
-      pk: 2,
-      event: defaultEvent2,
-      expiration: null,
-    },
-  ];
-
-  const [acks, setAcks] = useState<Acknowledgement[]>(defaultAcks);
+  useEffect(() => {
+    setAcksPromise(api.getIncidentAcks(incident.pk));
+    setEventsPromise(api.getIncidentEvents(incident.pk));
+  }, [setAcksPromise, setEventsPromise, incident]);
 
   const chronoAcks = useMemo<Acknowledgement[]>(() => {
-    return [...acks].sort((first: Acknowledgement, second: Acknowledgement) => {
+    return [...(acks || [])].sort((first: Acknowledgement, second: Acknowledgement) => {
       const firstTime = Date.parse(first.event.timestamp);
       const secondTime = Date.parse(second.event.timestamp);
       if (firstTime < secondTime) {
@@ -370,7 +339,7 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleManualClose = (msg: string) => {
     api
-      .postIncidentCloseEvent(incident.pk)
+      .postIncidentCloseEvent(incident.pk, msg)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .then((event: Event) => {
         // TODO: add close event to list of events
@@ -399,20 +368,42 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
   const ackExpiryDate = undefined;
 
   // TODO: get tag from incident
-  const tags = [
-    { key: "test_url", value: "https://uninett.no" },
-    { key: "test_host", value: "uninett.no" },
-    { key: "host", value: "uninett.no" },
-    { key: "timestamp", value: "123123123" },
-    { key: "bytes", value: "askldfjalskdf" },
-    { key: "origin_src", value: "something.tst" },
-  ];
+  const tags = useMemo(
+    () =>
+      incident.tags.map((tag: IncidentTag) => {
+        const [key, value] = tag.tag.split("=", 2);
+        return { key, value };
+      }),
+    [incident],
+  );
 
-  // {incidentSnackbar}
+  // These are just used for "skeletons" that are displayed
+  // when the data is loading.
+  const defaultEvent = {
+    pk: 1,
+    incident: 1,
+    actor: 2,
+    timestamp: "2011-11-11T11:11:11+02:00",
+    type: {
+      value: EventType.INCIDENT_START,
+      display: "Incident start",
+    },
+    description: "",
+  };
+
+  const defaultAck = {
+    pk: 1,
+    event: defaultEvent,
+    user: "testuser2",
+    timestamp: "2020-01-14T03:04:14.387000+01:00",
+    message: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vulputate id erat non pretium.",
+    expiration: "2020-02-14T03:04:14.387000+01:00",
+  };
+
   return (
     <div className={classes.root}>
       <Grid container spacing={3} className={classes.grid}>
-        <Grid container item spacing={2} md alignItems="stretch" justify="space-evenly" direction="column">
+        <Grid container item spacing={2} md alignItems="stretch" direction="column">
           <Grid item>
             <Card>
               <CardContent>
@@ -421,31 +412,12 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
                 </Typography>
                 <CenterContainer>
                   <OpenItem open={incident.open} />
-                  <AckedItem acked={true} expiration={ackExpiryDate} />
+                  <AckedItem acked={incident.acked} expiration={ackExpiryDate} />
                   <TicketItem ticketUrl={incident.ticket_url} />
                 </CenterContainer>
               </CardContent>
             </Card>
           </Grid>
-
-          {!incident.open && (
-            <Grid item>
-              <Card>
-                <CardContent>
-                  <Typography color="textSecondary" gutterBottom>
-                    Incident closed
-                  </Typography>
-                  <SignedMessage
-                    message={"Incident was resolved on servicerestart"}
-                    content={<Typography paragraph>Incident was resolved on servicerestart</Typography>}
-                    timestamp={new Date().toUTCString()}
-                    user={"you"}
-                    TextComponent={Typography}
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
-          )}
 
           <Grid item>
             <Card>
@@ -511,21 +483,29 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
               Acknowledgements
             </Typography>
             <List>
-              {chronoAcks.map((ack: Acknowledgement) => (
-                <AckListItem key={ack.event.timestamp} ack={ack} />
-              ))}
+              {(isAcksLoading &&
+                Array.from(new Array(3)).map((item: number, index: number) => (
+                  <Skeleton key={index} variant="rect" animation="wave">
+                    {" "}
+                    <AckListItem ack={defaultAck} />
+                  </Skeleton>
+                ))) ||
+                chronoAcks.map((ack: Acknowledgement) => <AckListItem key={ack.event.timestamp} ack={ack} />)}
             </List>
             <CenterContainer>
               <CreateAck
-                key={acks.length}
+                key={(acks || []).length}
                 onSubmitAck={(ack: AcknowledgementBody) => {
-                  // TODO: handle ack submit here
-                  console.log(ack);
                   api
                     .postAck(incident.pk, ack)
                     .then((ack: Acknowledgement) => {
-                      displayAlertSnackbar(`Submitted ack for ${incident && incident.pk}`, "success");
-                      setAcks([...acks, ack]);
+                      displayAlertSnackbar(
+                        `Submitted ${ack.event.type.display} for ${incident && incident.pk}`,
+                        "success",
+                      );
+                      // force reload everything
+                      setAcksPromise(api.getIncidentAcks(incident.pk));
+                      setEventsPromise(api.getIncidentEvents(incident.pk));
                     })
                     .catch((error) => {
                       displayAlertSnackbar(`Failed to post ack ${error}`, "error");
@@ -534,18 +514,24 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
               />
             </CenterContainer>
           </Grid>
+        </Grid>
+        <Grid container item spacing={2} md direction="column">
           <Grid item>
-            <Card>
-              <CardContent>
-                <Typography color="textSecondary" gutterBottom>
-                  Related events
-                </Typography>
-                <List>
-                  <EventListItem event={defaultEvent1} />
-                  <EventListItem event={defaultEvent2} />
-                </List>
-              </CardContent>
-            </Card>
+            <Typography color="textSecondary" gutterBottom>
+              Related events
+            </Typography>
+            <List>
+              {(isEventsLoading &&
+                Array.from(new Array(3)).map((item: number, index: number) => (
+                  <Skeleton key={index} variant="rect" animation="wave">
+                    {" "}
+                    <EventListItem event={defaultEvent} />
+                  </Skeleton>
+                ))) ||
+                (events || [])
+                  .filter((event: Event) => event.type.value !== "ACK")
+                  .map((event: Event) => <EventListItem key={event.pk} event={event} />)}
+            </List>
           </Grid>
         </Grid>
       </Grid>

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -213,7 +213,6 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
               <TableCell>Timestamp</TableCell>
               <TableCell>Status</TableCell>
               <TableCell>Source</TableCell>
-              <TableCell>Details</TableCell>
               <TableCell>Description</TableCell>
               <TableCell>Actions</TableCell>
             </TableRow>
@@ -248,7 +247,6 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
                       <AckedItem small acked />
                     </ClickableCell>
                     <ClickableCell>{incident.source.name}</ClickableCell>
-                    <ClickableCell>{<a href={incident.details_url}>{incident.details_url}</a>}</ClickableCell>
                     <ClickableCell>{incident.description}</ClickableCell>
                     <TableCell>
                       <Button className={classes.safeButton} onClick={() => onShowDetail(incident)}>

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -244,7 +244,7 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
                     <ClickableCell component="th" scope="row">
                       <OpenItem small open={incident.open} />
                       <TicketItem small ticketUrl={incident.ticket_url} />
-                      <AckedItem small acked />
+                      <AckedItem small acked={incident.acked} />
                     </ClickableCell>
                     <ClickableCell>{incident.source.name}</ClickableCell>
                     <ClickableCell>{incident.description}</ClickableCell>

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -78,6 +78,27 @@ export function toMap<K extends number | string, T>(elements: T[], getter: (elem
   return new Map<K, T>(elements.map((elem: T, index: number): [K, T] => [getter(elem, index), elem]));
 }
 
+export function groupBy<K extends number | string, T>(
+  elements: T[],
+  groupByGetter: (elem: T, index: number) => K,
+): Map<K, Set<T>> {
+  const map = new Map<K, Set<T>>();
+  elements.forEach((elem: T, index: number) => {
+    const group = groupByGetter(elem, index);
+    if (map.has(group)) {
+      const groupSet = map.get(group) || new Set();
+      groupSet.add(elem);
+      map.set(group, groupSet);
+    } else {
+      map.set(
+        group,
+        new Set<T>([elem]),
+      );
+    }
+  });
+  return map;
+}
+
 export function pkGetter<K, T extends { pk: K }>(elem: T): K {
   return elem.pk;
 }


### PR DESCRIPTION
Incident details modal:
 - Fetches acknowledgements and other  related events from Argus API

 - Displays the acks and events in a nice list

 - The "Create acknowledgement" button now will actually create an acknowledgement.

Tag filtering:
 - Tags of the same "type" (same key) works
   as an OR, meaning that if the following
   tags are used:

     host=testhost1, host=testhost2

   Incidents with either the tag "host=testhost1"
   or the tag "host=testhost2" will be shown,
   but all other values for host will be filtered
   out.

 - Tags of different "types" works as an AND,
   meaning that if the following tags are used:

     host=testhost1, host=testhost2,
     ticket_url=http://tr.t/123

   Only the incidents with host in (testhost1, testhost2)
   AND with ticket_url equal to http://tr.t/123
   will be displayed.