### PR TITLE
Implement "show acked incidents" checkbox for incident view

### DIFF
--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -475,6 +475,14 @@ export class ApiClient {
     );
   }
 
+  public getOpenUnAckedIncidents(): Promise<Incident[]> {
+    return resolveOrReject(
+      this.authGet<Incident[], never>(`/api/v1/incidents/open+unacked/`),
+      defaultResolver,
+      (error) => new Error(`Failed to get incidents: ${error}`),
+    );
+  }
+
   public getAllIncidentsMetadata(): Promise<IncidentMetadata> {
     return resolveOrReject(
       this.authGet<IncidentMetadata, never>(`/api/v1/incidents/metadata/`),

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -317,6 +317,11 @@ const IncidentTable: React.FC<IncidentsProps> = ({ incidents, realtime, open }: 
   };
 
   const handleIncidentChange = (incident: Incident) => {
+    // TODO: handle acked/unacked changes as well because there is now
+    // the showAcked variable in the "supercomponent" IncidentView that
+    // passes the incidents to the incidentstable.
+    // An alternative is to have a "filter" function that is passed to
+    // this component from the composing component.
     setIncidentsDict((oldDict: Revisioned<Map<Incident["pk"], Incident>>) => {
       const newDict: typeof oldDict = new Map<Incident["pk"], Incident>(oldDict);
       const oldIncident = oldDict.get(incident.pk);

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -138,6 +138,7 @@ type IncidentViewPropsType = {};
 
 const IncidentView: React.FC<IncidentViewPropsType> = ({}: IncidentViewPropsType) => {
   const [realtime, setRealtime] = useState<boolean>(true);
+  const [showAcked, setShowAcked] = useState<boolean>(false);
   const [tagsFilter, setTagsFilter] = useState<Tag[]>([]);
   const [sources, setSources] = useState<Set<string> | "AllSources">("AllSources");
   const [show, setShow] = useState<"open" | "closed" | "both">("open");
@@ -224,9 +225,10 @@ const IncidentView: React.FC<IncidentViewPropsType> = ({}: IncidentViewPropsType
     return (
       filteredByTags
         .filter((incident: Incident) => (show === "open" ? incident.open : show === "closed" ? !incident.open : true))
+        .filter((incident: Incident) => showAcked || !incident.acked)
         .filter(filterOnSources) || []
     );
-  }, [incidentsMap, incidentsTags, show, tagsFilter, sources]);
+  }, [incidentsMap, incidentsTags, show, showAcked, tagsFilter, sources]);
 
   const sourceAlts = useMemo(
     () => [...new Set([...(incidents || []).map((incident: Incident) => incident.source.name)]).values()],
@@ -256,9 +258,15 @@ const IncidentView: React.FC<IncidentViewPropsType> = ({}: IncidentViewPropsType
             </Grid>
 
             <Grid item md>
+              <Typography>Show acked events</Typography>
+              <Checkbox checked={showAcked} onClick={() => setShowAcked((old) => !old)} />
+            </Grid>
+
+            <Grid item md>
               <Typography>Realtime</Typography>
               <Checkbox checked={realtime} onClick={() => setRealtime((old) => !old)} />
             </Grid>
+
             <Grid item md>
               <Typography>Sources to display</Typography>
               <SourceSelector

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -152,9 +152,11 @@ const IncidentView: React.FC<IncidentViewPropsType> = ({}: IncidentViewPropsType
   const [{ result: incidents, isLoading, isError }, setPromise] = useApiIncidents();
 
   useEffect(() => {
-    if (show === "open") setPromise(api.getOpenIncidents());
-    else setPromise(api.getAllIncidents());
-  }, [setPromise, show]);
+    if (show === "open") {
+      if (showAcked) setPromise(api.getOpenIncidents());
+      else setPromise(api.getOpenUnAckedIncidents());
+    } else setPromise(api.getAllIncidents());
+  }, [setPromise, show, showAcked]);
 
   const noDataText = isLoading ? LOADING_TEXT : isError ? ERROR_TEXT : NO_DATA_TEXT;
 


### PR DESCRIPTION
This now makes it possible to conditionally display the acknowledged incidents, but will by default only display open+unacknowledged incidents.

When the "open" option for "show open/closed" is used it will use the "open+unacked" endpoint when this checkbox option is disabled. When it is enabled it will use the "open" endpoint.