### PR TITLE
Improve title of incident detail box

### DIFF
--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -25,7 +25,7 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import TablePagination from "@material-ui/core/TablePagination";
 
-import { useStateWithDynamicDefault, toMap, pkGetter } from "../../utils";
+import { useStateWithDynamicDefault, toMap, pkGetter, truncateMultilineString } from "../../utils";
 
 import { useAlertSnackbar, UseAlertSnackbarResultType } from "../../components/alertsnackbar";
 
@@ -464,7 +464,7 @@ const IncidentTable: React.FC<IncidentsProps> = ({ incidents, realtime, open, is
                     <CloseIcon />
                   </IconButton>
                   <Typography variant="h6" className={classes.title}>
-                    {incidentForDetail.pk}: {incidentForDetail.description}
+                    {truncateMultilineString(incidentForDetail.description, 50)}
                   </Typography>
                 </Toolbar>
               </AppBar>

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -464,7 +464,7 @@ const IncidentTable: React.FC<IncidentsProps> = ({ incidents, realtime, open, is
                     <CloseIcon />
                   </IconButton>
                   <Typography variant="h6" className={classes.title}>
-                    Incident {incidentForDetail.pk}
+                    {incidentForDetail.pk}: {incidentForDetail.description}
                   </Typography>
                 </Toolbar>
               </AppBar>

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -118,3 +118,11 @@ export function dateFromTimeOfDayString(timeOfDay: string): Date {
   const [hours, minutes, seconds] = timeOfDay.split(":").map((str: string) => Number.parseInt(str));
   return new Date(1970, 1, 1, hours, minutes, seconds);
 }
+
+export function truncateMultilineString(multilineString: string, length: number): string {
+    const truncatedString = multilineString.split('\n', 1)[0].slice(0, length) + "…";
+    if (truncatedString.length < multilineString.length) {
+        return truncatedString;
+    }
+   return multilineString;
+}


### PR DESCRIPTION
Closes #121 

It's a little odd that this part of the details box is defined in the incident table, not the incident detail box itself. Not something we should bother to fix before 1.0 though.

@lunkwill42, I've tagged you because exactly what we ought to have as the title of the box is very much up for discussion. It's very easy to change though, as long as only things stored directly on the incident are used.