### PR TITLE
Only linkify details_url if absolute

### DIFF
--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -106,6 +106,14 @@ const isValidUrl = (url: string) => {
   return true;
 };
 
+const formatUrlOrIdentity = (url: string, title: string, empty: string = "") => {
+  if (isValidUrl(url || "")) {
+    return <a href={url}>{title}</a>;
+  } else {
+    return url || empty;
+  }
+};
+
 const TagChip: React.FC<TagChipPropsType> = ({ tag, small }: TagChipPropsType) => {
   if (isValidUrl(tag.value)) {
     return (
@@ -450,7 +458,7 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
                   <IncidentDetailsListItem title="Source" detail={incident.source.name} />
                   <IncidentDetailsListItem
                     title="Details URL"
-                    detail={<a href={incident.details_url}>{incident.details_url}</a>}
+                    detail={formatUrlOrIdentity(incident.details_url, "More details", "–")}
                   />
 
                   <TicketModifiableField

--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -106,11 +106,11 @@ const isValidUrl = (url: string) => {
   return true;
 };
 
-const formatUrlOrIdentity = (url: string, title: string, empty: string = "") => {
-  if (isValidUrl(url || "")) {
+const hyperlinkIfAbsoluteUrl = (url: string, title: string) => {
+  if (isValidUrl(url)) {
     return <a href={url}>{title}</a>;
   } else {
-    return url || empty;
+    return url;
   }
 };
 
@@ -458,7 +458,7 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
                   <IncidentDetailsListItem title="Source" detail={incident.source.name} />
                   <IncidentDetailsListItem
                     title="Details URL"
-                    detail={formatUrlOrIdentity(incident.details_url, "More details", "–")}
+                    detail={hyperlinkIfAbsoluteUrl(incident.details_url, "More details") || "–"}
                   />
 
                   <TicketModifiableField


### PR DESCRIPTION
Closes #143, independently of what the backend does.

Closes #125 as well.

An empty details_url field is shown by an en dash in the UI.