### PR TITLE
Fix incorrect URL for realtime updates

### DIFF
--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -347,7 +347,7 @@ const IncidentTable: React.FC<IncidentsProps> = ({
   useEffect(() => {
     if (!realtime) return;
 
-    const ws = new WebSocket(`${BACKEND_WS_URL}/active/`);
+    const ws = new WebSocket(`${BACKEND_WS_URL}/open/`);
     // cookies.set("token", token, { path: "/", secure: USE_SECURE_COOKIE });
     console.log("websocket", ws);
 


### PR DESCRIPTION
Realtime updates are not working in v1.0.0 or v1.0.1 - apparently, the frontend is requesting the **wrong** backend URL for realtime updates.