### PR TITLE
Add missing header to FiltersView

### DIFF
--- a/src/views/filters/FiltersView.tsx
+++ b/src/views/filters/FiltersView.tsx
@@ -19,6 +19,7 @@ import Spinning from "../../components/spinning";
 
 import { ENABLE_WEBSOCKETS_SUPPORT } from "../../config";
 
+import Header from "../../components/header/Header";
 import "../../components/incidenttable/incidenttable.css";
 import FilterBuilder from "../../components/filterbuilder/FilterBuilder";
 import { withRouter } from "react-router-dom";
@@ -313,6 +314,9 @@ const FiltersView: React.FC<FiltersViewPropsType> = ({}: FiltersViewPropsType) =
     <>
       {filtersSnackbar}
       <div>
+        <header>
+          <Header />
+        </header>
         <FiltersContext.Provider value={filtersContext}>
           <Card>
             <CardContent>


### PR DESCRIPTION
Somehow the header has been missing form the filters view for some time now. This just adds it back like the other views does it at the current HEAD.

Closes #172 