### PR TITLE
Add route for showing incident by canonical url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,21 @@ import auth from "./auth";
 import { ThemeProvider } from "@material-ui/core/styles";
 import { MUI_THEME } from "./colorscheme";
 
+import Header from "./components/header/Header";
+
+// eslint-disable-next-line
+const withHeader = (Component: any) => {
+  // eslint-disable-next-line
+  return (props: any) => (
+    <>
+      <header>
+        <Header />
+      </header>
+      <Component {...props} />
+    </>
+  );
+};
+
 const App: React.SFC = () => {
   const history = useHistory();
   api.registerUnauthorizedCallback(() => {
@@ -28,12 +43,13 @@ const App: React.SFC = () => {
     <div>
       <ThemeProvider theme={MUI_THEME}>
         <Switch>
-          <ProtectedRoute exact path="/" component={IncidentView} />
-          <ProtectedRoute path="/notificationprofiles" component={NotificationProfileView} />
-          <ProtectedRoute path="/timeslots" component={TimeslotView} />
-          <ProtectedRoute path="/settings" component={SettingsView} />
+          <ProtectedRoute exact path="/" component={withHeader(IncidentView)} />
+          <ProtectedRoute exact path="/incidents" component={withHeader(IncidentView)} />
+          <ProtectedRoute path="/notificationprofiles" component={withHeader(NotificationProfileView)} />
+          <ProtectedRoute path="/timeslots" component={withHeader(TimeslotView)} />
+          <ProtectedRoute path="/settings" component={withHeader(SettingsView)} />
+          <ProtectedRoute path="/filters" component={withHeader(FiltersView)} />
           <Route path="/login" component={LoginView} />
-          <ProtectedRoute path="/filters" component={FiltersView} />
           <Route
             path="*"
             component={() => (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import React from "react";
+
 import "./variables.css";
 import "./colorscheme.css";
+
+import IncidentDetailsView from "./views/incident/IncidentDetailView";
 import IncidentView from "./views/incident/IncidentView";
 import LoginView from "./views/login/LoginView";
 import { Route, Switch, useHistory } from "react-router-dom";
@@ -44,6 +47,7 @@ const App: React.SFC = () => {
       <ThemeProvider theme={MUI_THEME}>
         <Switch>
           <ProtectedRoute exact path="/" component={withHeader(IncidentView)} />
+          <ProtectedRoute path="/incidents/:pk" component={withHeader(IncidentDetailsView)} />
           <ProtectedRoute exact path="/incidents" component={withHeader(IncidentView)} />
           <ProtectedRoute path="/notificationprofiles" component={withHeader(NotificationProfileView)} />
           <ProtectedRoute path="/timeslots" component={withHeader(TimeslotView)} />

--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -594,6 +594,14 @@ export class ApiClient {
     }
   }
 
+  public getIncident(pk: Incident["pk"]): Promise<Incident> {
+    return resolveOrReject(
+      this.authGet<Incident, never>(`/api/v1/incidents/${pk}/`),
+      defaultResolver,
+      (error) => new Error(`Failed to get incident with pk=${pk}: ${error}`),
+    );
+  }
+
   // NOTE: This won't actually get all incidents anymore because of the pagination
   // TODO: Remove all use of this method.
   public getAllIncidentsFiltered(filter: IncidentsFilterOptions): Promise<Incident[]> {

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from "react";
+
+import Button from "@material-ui/core/Button";
+import ButtonGroup from "@material-ui/core/ButtonGroup";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Checkbox from "@material-ui/core/Checkbox";
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
+
+import { ENABLE_WEBSOCKETS_SUPPORT } from "../../config";
+
+import { IncidentsFilter } from "../../components/incidenttable/FilteredIncidentTable";
+
+import TagSelector, { Tag } from "../../components/tagselector";
+import SourceSelector from "../../components/sourceselector";
+
+import api, { IncidentMetadata, SourceSystem } from "../../api";
+
+type IncidentFilterToolbarPropsType = {
+  filter: IncidentsFilter;
+  onFilterChange: (filter: IncidentsFilter) => void;
+  disabled?: boolean;
+};
+
+export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = ({
+  filter,
+  onFilterChange,
+  disabled,
+}: IncidentFilterToolbarPropsType) => {
+  const [knownSources, setKnownSources] = useState<string[]>([]);
+
+  useEffect(() => {
+    api.getAllIncidentsMetadata().then((incidentMetadata: IncidentMetadata) => {
+      setKnownSources(incidentMetadata.sourceSystems.map((source: SourceSystem) => source.name));
+    });
+  }, []);
+
+  const onShowChange = (show: "open" | "closed" | "both") => {
+    onFilterChange({ ...filter, show });
+  };
+
+  const onShowAchedChange = (showAcked: boolean) => {
+    onFilterChange({ ...filter, showAcked });
+  };
+
+  const onRealtimeChange = (realtime: boolean) => {
+    onFilterChange({ ...filter, realtime });
+  };
+
+  const onSourcesChange = (sources: string[] | "AllSources" | undefined) => {
+    onFilterChange({ ...filter, sources });
+  };
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography color="textSecondary" gutterBottom>
+          Incidents filter
+        </Typography>
+        <Grid container xl direction="row" justify="space-evenly" spacing={4}>
+          <Grid item container sm={5} direction="row">
+            <Grid item sm>
+              <Typography>State</Typography>
+
+              <ButtonGroup variant="contained" color="default" aria-label="text primary button group">
+                <Button color={filter.show === "open" ? "primary" : undefined} onClick={() => onShowChange("open")}>
+                  Open
+                </Button>
+                <Button color={filter.show === "closed" ? "primary" : undefined} onClick={() => onShowChange("closed")}>
+                  Closed
+                </Button>
+                <Button color={filter.show === "both" ? "primary" : undefined} onClick={() => onShowChange("both")}>
+                  Both
+                </Button>
+              </ButtonGroup>
+            </Grid>
+
+            <Grid item sm>
+              <Typography>Acked</Typography>
+              <ButtonGroup variant="contained" color="default" aria-label="text primary button group">
+                <Button color={!filter.showAcked ? "primary" : undefined} onClick={() => onShowAchedChange(false)}>
+                  Only unacked
+                </Button>
+                <Button color={filter.showAcked ? "primary" : undefined} onClick={() => onShowAchedChange(true)}>
+                  All
+                </Button>
+              </ButtonGroup>
+            </Grid>
+          </Grid>
+
+          {ENABLE_WEBSOCKETS_SUPPORT && (
+            <Grid item md>
+              <Typography>Realtime</Typography>
+              <Checkbox
+                disabled={disabled}
+                checked={filter.realtime}
+                onClick={() => onRealtimeChange(!filter.realtime)}
+              />
+            </Grid>
+          )}
+
+          <Grid item container md direction="row" spacing={4}>
+            <Grid item md>
+              <Typography>Sources to display</Typography>
+              <SourceSelector
+                disabled={disabled}
+                sources={knownSources}
+                onSelectionChange={(selection: string[]) => {
+                  onSourcesChange((selection.length !== 0 && selection) || "AllSources");
+                }}
+                defaultSelected={filter.sources === "AllSources" ? [] : filter.sources || []}
+              />
+            </Grid>
+
+            <Grid item md>
+              <Typography>Tags filter</Typography>
+              <TagSelector
+                disabled={disabled}
+                tags={filter.tags}
+                onSelectionChange={(selection: Tag[]) =>
+                  selection.length !== 0 && selection && onFilterChange({ ...filter, tags: selection })
+                }
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -11,8 +11,12 @@ import CloseIcon from "@material-ui/icons/Close";
 import FilterListIcon from "@material-ui/icons/FilterList";
 import CheckSharpIcon from "@material-ui/icons/CheckSharp";
 import LinkSharpIcon from "@material-ui/icons/LinkSharp";
+import LinkIcon from "@material-ui/icons/Link";
+import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 import Paper from "@material-ui/core/Paper";
 import Checkbox from "@material-ui/core/Checkbox";
+
+import TicketIcon from "@material-ui/icons/LocalOffer";
 
 import Typography from "@material-ui/core/Typography";
 
@@ -236,25 +240,21 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
                     <ClickableCell>{formatTimestamp(incident.start_time)}</ClickableCell>
                     <ClickableCell component="th" scope="row">
                       <OpenItem small open={incident.open} />
-                      <TicketItem small ticketUrl={incident.ticket_url} />
+                      {/* <TicketItem small ticketUrl={incident.ticket_url} /> */}
                       <AckedItem small acked={incident.acked} />
                     </ClickableCell>
                     <ClickableCell>{incident.source.name}</ClickableCell>
                     <ClickableCell>{incident.description}</ClickableCell>
                     <TableCell>
-                      <Button
-                        disabled={isLoading}
-                        className={classes.safeButton}
-                        onClick={() => onShowDetail(incident)}
-                      >
-                        Details
-                      </Button>
-                      {/* TODO: Not implementd yet */}
-                      {false && (
-                        <Button disabled={isLoading} className={classes.safeButton} href="https://localhost.com">
-                          Ticket
-                        </Button>
+                      <IconButton disabled={isLoading} href={`/incidents/${incident.pk}/`}>
+                        <OpenInNewIcon />
+                      </IconButton>
+                      {incident.ticket_url && (
+                        <IconButton disabled={isLoading} href={incident.ticket_url}>
+                          <TicketIcon />
+                        </IconButton>
                       )}
+                      {/* TODO: Not implementd yet */}
                     </TableCell>
                   </TableRow>
                 );

--- a/src/views/filters/FiltersView.tsx
+++ b/src/views/filters/FiltersView.tsx
@@ -19,7 +19,6 @@ import Spinning from "../../components/spinning";
 
 import { ENABLE_WEBSOCKETS_SUPPORT } from "../../config";
 
-import Header from "../../components/header/Header";
 import "../../components/incidenttable/incidenttable.css";
 import FilterBuilder from "../../components/filterbuilder/FilterBuilder";
 import { withRouter } from "react-router-dom";
@@ -313,41 +312,36 @@ const FiltersView: React.FC<FiltersViewPropsType> = ({}: FiltersViewPropsType) =
   return (
     <>
       {filtersSnackbar}
-      <div>
-        <header>
-          <Header />
-        </header>
-        <FiltersContext.Provider value={filtersContext}>
-          <Card>
-            <CardContent>
-              <Typography variant="h5" gutterBottom>
-                Your incident filters
-              </Typography>
+      <FiltersContext.Provider value={filtersContext}>
+        <Card>
+          <CardContent>
+            <Typography variant="h5" gutterBottom>
+              Your incident filters
+            </Typography>
 
-              <FiltersTable
-                filters={filters}
-                onFilterPreview={handleFilterPreview}
-                onFilterEdit={(filter: Filter) => {
-                  setEditingFilter(filter);
-                }}
-                onFilterDelete={handleFilterDelete}
-              />
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent>
-              <Typography variant="h5" gutterBottom>
-                Create and preview filters
-              </Typography>
-              {filterBuilder}
-              <Typography color="textSecondary" gutterBottom>
-                Incidents matching filter
-              </Typography>
-              <FilteredIncidentTable filter={previewFilter} onLoad={useCallback(() => handleIncidentsLoaded(), [])} />
-            </CardContent>
-          </Card>
-        </FiltersContext.Provider>
-      </div>
+            <FiltersTable
+              filters={filters}
+              onFilterPreview={handleFilterPreview}
+              onFilterEdit={(filter: Filter) => {
+                setEditingFilter(filter);
+              }}
+              onFilterDelete={handleFilterDelete}
+            />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <Typography variant="h5" gutterBottom>
+              Create and preview filters
+            </Typography>
+            {filterBuilder}
+            <Typography color="textSecondary" gutterBottom>
+              Incidents matching filter
+            </Typography>
+            <FilteredIncidentTable filter={previewFilter} onLoad={useCallback(() => handleIncidentsLoaded(), [])} />
+          </CardContent>
+        </Card>
+      </FiltersContext.Provider>
     </>
   );
 };

--- a/src/views/incident/IncidentDetailView.tsx
+++ b/src/views/incident/IncidentDetailView.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+
+import { BrowserRouter as Router, Switch, Route, Link, useParams } from "react-router-dom";
+
+import Typography from "@material-ui/core/Typography";
+
+import api, { Incident } from "../../api";
+import { useAlertSnackbar, UseAlertSnackbarResultType } from "../../components/alertsnackbar";
+
+import IncidentDetails from "../../components/incident/IncidentDetails";
+
+type IncidentDetailsViewPropsType = {};
+
+export const IncidentDetailsView: React.FC<IncidentDetailsViewPropsType> = ({}: IncidentDetailsViewPropsType) => {
+  const { pk } = useParams<{ pk: string | undefined }>();
+
+  const { incidentSnackbar, displayAlertSnackbar }: UseAlertSnackbarResultType = useAlertSnackbar();
+  const [incident, setIncident] = useState<Incident | undefined | null>(undefined);
+
+  useEffect(() => {
+    api
+      .getIncident(Number.parseInt(pk || "0"))
+      .then((incident: Incident) => {
+        setIncident(incident);
+      })
+      .catch(() => {
+        displayAlertSnackbar(`Failed to get incident with pk=${pk}`, "error");
+        setIncident(null);
+      });
+    // FIXME:
+    // eslint-disable-next-line
+  }, [pk]);
+
+  if (incident === undefined) {
+    return <Typography>Loading...</Typography>;
+  } else if (incident === null) {
+    return <Typography>No such incident</Typography>;
+  }
+
+  return (
+    <>
+      {incidentSnackbar}
+      <IncidentDetails
+        incident={incident}
+        onIncidentChange={(incident: Incident) => setIncident(incident)}
+        displayAlertSnackbar={displayAlertSnackbar}
+      />
+    </>
+  );
+};
+
+export default IncidentDetailsView;

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
 import "./IncidentView.css";
-import Header from "../../components/header/Header";
 import FilteredIncidentTable from "../../components/incidenttable/FilteredIncidentTable";
 import "../../components/incidenttable/incidenttable.css";
 import { withRouter } from "react-router-dom";
@@ -50,10 +49,6 @@ const IncidentView: React.FC<IncidentViewPropsType> = ({}: IncidentViewPropsType
 
   return (
     <div>
-      <header>
-        <Header />
-      </header>
-      <h1 className={"filterHeader"}>Incidents</h1>
       <Card>
         <CardContent>
           <Typography color="textSecondary" gutterBottom>

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -1,127 +1,30 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 import "./IncidentView.css";
-import FilteredIncidentTable from "../../components/incidenttable/FilteredIncidentTable";
-import "../../components/incidenttable/incidenttable.css";
 import { withRouter } from "react-router-dom";
 
-import Checkbox from "@material-ui/core/Checkbox";
-import Card from "@material-ui/core/Card";
-import CardContent from "@material-ui/core/CardContent";
-import Button from "@material-ui/core/Button";
-import ButtonGroup from "@material-ui/core/ButtonGroup";
-import Grid from "@material-ui/core/Grid";
-import Typography from "@material-ui/core/Typography";
-
-import api, { IncidentMetadata, SourceSystem } from "../../api";
-
-import TagSelector, { Tag } from "../../components/tagselector";
-import SourceSelector from "../../components/sourceselector";
+import FilteredIncidentTable, { IncidentsFilter } from "../../components/incidenttable/FilteredIncidentTable";
+import "../../components/incidenttable/incidenttable.css";
 
 import { ENABLE_WEBSOCKETS_SUPPORT } from "../../config";
+
+import { IncidentFilterToolbar } from "../../components/incident/IncidentFilterToolbar";
 
 type IncidentViewPropsType = {};
 
 const IncidentView: React.FC<IncidentViewPropsType> = ({}: IncidentViewPropsType) => {
-  const [realtime, setRealtime] = useState<boolean>(ENABLE_WEBSOCKETS_SUPPORT);
-  const [showAcked, setShowAcked] = useState<boolean>(false);
-  const [tagsFilter, setTagsFilter] = useState<Tag[]>([]);
-  const [sources, setSources] = useState<string[] | "AllSources">("AllSources");
-  const [show, setShow] = useState<"open" | "closed" | "both">("open");
-
-  const [knownSources, setKnownSources] = useState<string[]>([]);
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [tags, setTags] = useState<Tag[]>([
-    { key: "url", value: "https://test.test", original: "url=https://test.test" },
-    { key: "host", value: "localhost", original: "host=localhost" },
-  ]);
-
-  useEffect(() => {
-    api.getAllIncidentsMetadata().then((incidentMetadata: IncidentMetadata) => {
-      setKnownSources(incidentMetadata.sourceSystems.map((source: SourceSystem) => source.name));
-    });
-  }, []);
-
-  // const handleShowChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-  //   setShow(event.target.value as "open" | "closed" | "both");
-  // };
-  const disabled = false;
+  const [filter, setFilter] = useState<IncidentsFilter>({
+    realtime: ENABLE_WEBSOCKETS_SUPPORT,
+    showAcked: false,
+    tags: [],
+    sources: "AllSources",
+    sourcesById: undefined,
+    show: "open",
+  });
 
   return (
     <div>
-      <Card>
-        <CardContent>
-          <Typography color="textSecondary" gutterBottom>
-            Incidents filter
-          </Typography>
-          <Grid container xl direction="row" justify="space-evenly" spacing={4}>
-            <Grid item container sm={5} direction="row">
-              <Grid item sm>
-                <Typography>State</Typography>
-
-                <ButtonGroup variant="contained" color="default" aria-label="text primary button group">
-                  <Button color={show === "open" ? "primary" : undefined} onClick={() => setShow("open")}>
-                    Open
-                  </Button>
-                  <Button color={show === "closed" ? "primary" : undefined} onClick={() => setShow("closed")}>
-                    Closed
-                  </Button>
-                  <Button color={show === "both" ? "primary" : undefined} onClick={() => setShow("both")}>
-                    Both
-                  </Button>
-                </ButtonGroup>
-              </Grid>
-
-              <Grid item sm>
-                <Typography>Acked</Typography>
-                <ButtonGroup variant="contained" color="default" aria-label="text primary button group">
-                  <Button color={!showAcked ? "primary" : undefined} onClick={() => setShowAcked(false)}>
-                    Only unacked
-                  </Button>
-                  <Button color={showAcked ? "primary" : undefined} onClick={() => setShowAcked(true)}>
-                    All
-                  </Button>
-                </ButtonGroup>
-              </Grid>
-            </Grid>
-
-            {ENABLE_WEBSOCKETS_SUPPORT && (
-              <Grid item md>
-                <Typography>Realtime</Typography>
-                <Checkbox disabled={disabled} checked={realtime} onClick={() => setRealtime((old) => !old)} />
-              </Grid>
-            )}
-
-            <Grid item container md direction="row" spacing={4}>
-              <Grid item md>
-                <Typography>Sources to display</Typography>
-                <SourceSelector
-                  disabled={disabled}
-                  sources={knownSources}
-                  onSelectionChange={(selection: string[]) => {
-                    setSources((selection.length !== 0 && selection) || "AllSources");
-                  }}
-                  defaultSelected={sources === "AllSources" ? [] : sources}
-                />
-              </Grid>
-
-              <Grid item md>
-                <Typography>Tags filter</Typography>
-                <TagSelector
-                  disabled={disabled}
-                  tags={tags}
-                  onSelectionChange={useCallback((selection: Tag[]) => {
-                    setTagsFilter(selection);
-                  }, [])}
-                />
-              </Grid>
-            </Grid>
-          </Grid>
-        </CardContent>
-      </Card>
-      <FilteredIncidentTable
-        filter={{ tags: tagsFilter, sources, sourcesById: undefined, show, showAcked, realtime }}
-      />
+      <IncidentFilterToolbar filter={filter} onFilterChange={setFilter} />
+      <FilteredIncidentTable filter={filter} />
     </div>
   );
 };

--- a/src/views/notificationprofile/NotificationProfileView.tsx
+++ b/src/views/notificationprofile/NotificationProfileView.tsx
@@ -1,16 +1,11 @@
 import React from "react";
 import "./NotificationProfileView.css";
-import Header from "../../components/header/Header";
 import { withRouter } from "react-router-dom";
 import ProfileList from "../../components/profilelist/ProfileList";
 
 const NotificationProfileView: React.FC = () => {
   return (
     <div>
-      <header>
-        <Header />
-      </header>
-      <h1>Notification Profiles</h1>
       <div className="profileList-container">
         <ProfileList />
       </div>

--- a/src/views/settings/SettingsView.tsx
+++ b/src/views/settings/SettingsView.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import "./SettingsView.css";
-import Header from "../../components/header/Header";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import { withRouter } from "react-router-dom";
@@ -10,9 +9,6 @@ import PhoneNumberList from "../../components/phonenumberlist";
 const SettingsView: React.FC = () => {
   return (
     <div>
-      <header>
-        <Header />
-      </header>
       <h1>Settings</h1>
       <Grid container direction="column" justify="space-evenly" alignItems="center">
         <Typography variant="h5">Phone numbers</Typography>

--- a/src/views/timeslot/TimeslotView.tsx
+++ b/src/views/timeslot/TimeslotView.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { withRouter } from "react-router-dom";
-import Header from "../../components/header/Header";
-import Typography from "@material-ui/core/Typography";
 import Grid from "@material-ui/core/Grid";
 
 import TimeslotList from "../../components/timeslotlist";
@@ -9,9 +7,7 @@ import TimeslotList from "../../components/timeslotlist";
 const TimeslotView: React.FC = () => {
   return (
     <div className="timeslot-view-container">
-      <Header />
       <Grid container direction="column" justify="space-evenly" alignItems="center">
-        <Typography variant="h3">Timeslots</Typography>
         <TimeslotList />
       </Grid>
     </div>


### PR DESCRIPTION
This PR implements the required functionality of #148.

It includes the following:
- [X] Split the incident view => incident view, incident detail component, incident toolbar component
- [X] Make URLs on the form: /incident/<incident pk> open a view consisting of only the incident details

This required refactoring of <Header/> component usage. 

Closes #148