### PR TITLE
Minor improvements to incidents toolbar, new feature of an drop-down with additional setting 

### DIFF
--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -185,19 +185,19 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
   }, []);
 
   const onShowChange = (show: "open" | "closed" | "both") => {
-    onFilterChange({ ...filter, show });
+    if (show !== filter.show) onFilterChange({ ...filter, show });
   };
 
   const onShowAchedChange = (showAcked: boolean) => {
-    onFilterChange({ ...filter, showAcked });
+    if (showAcked !== filter.showAcked) onFilterChange({ ...filter, showAcked });
   };
 
   const onAutoUpdateChange = (autoUpdate: AutoUpdate) => {
-    onFilterChange({ ...filter, autoUpdate });
+    if (autoUpdate !== filter.autoUpdate) onFilterChange({ ...filter, autoUpdate });
   };
 
   const onSourcesChange = (sources: string[] | "AllSources" | undefined) => {
-    onFilterChange({ ...filter, sources });
+    if (sources !== filter.sources) onFilterChange({ ...filter, sources });
   };
 
   const autoUpdateOptions: AutoUpdate[] = ENABLE_WEBSOCKETS_SUPPORT
@@ -219,6 +219,13 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
       />
     </ToolbarItem>
   );
+
+  const handleTagSelectionChange = (selection: Tag[]) => {
+    // compare the arrays deeply
+    if (JSON.stringify(selection) !== JSON.stringify(filter.tags)) {
+      onFilterChange({ ...filter, tags: selection });
+    }
+  };
 
   return (
     <div className={style.root}>
@@ -255,13 +262,7 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
         </ToolbarItem>
 
         <ToolbarItem name="Tags" className={classNames(style.large, style.rightAligned)}>
-          <TagSelector
-            disabled={disabled}
-            tags={filter.tags}
-            onSelectionChange={(selection: Tag[]) =>
-              selection.length !== 0 && selection && onFilterChange({ ...filter, tags: selection })
-            }
-          />
+          <TagSelector disabled={disabled} tags={filter.tags} onSelectionChange={handleTagSelectionChange} />
         </ToolbarItem>
 
         <MoreSettingsToolbarItem

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -5,6 +5,8 @@ import ButtonGroup from "@material-ui/core/ButtonGroup";
 import Checkbox from "@material-ui/core/Checkbox";
 import Typography from "@material-ui/core/Typography";
 import Toolbar from "@material-ui/core/Toolbar";
+import IconButton from "@material-ui/core/IconButton";
+import SettingsIcon from "@material-ui/icons/Settings";
 
 import { ENABLE_WEBSOCKETS_SUPPORT } from "../../config";
 
@@ -50,6 +52,19 @@ const useStyles = makeStyles((theme: Theme) =>
       display: "flex",
       flexFlow: "column wrap",
       margin: theme.spacing(1),
+    },
+    dropdownContainer: {
+      display: "block",
+      flexFlow: "column wrap",
+      color: theme.palette.getContrastText(theme.palette.primary.dark),
+      background: theme.palette.primary.dark,
+      boxShadow: "0 4px 8px 0 rgba(0, 0, 0, 0.2) inset, 0 6px 20px 0 rgba(0, 0, 0, 0.19) inset",
+      width: "auto",
+      padding: theme.spacing(2),
+      margin: 0,
+    },
+    moreSettingsItemContainer: {
+      alignSelf: "center",
     },
   }),
 );
@@ -98,6 +113,56 @@ export const ToolbarItem: React.FC<ToolbarItemPropsType> = ({ name, children, cl
   );
 };
 
+type DropdownToolbarPropsType = {
+  open: boolean;
+  onClose: () => void;
+
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const DropdownToolbar: React.FC<DropdownToolbarPropsType> = ({
+  open,
+  children,
+  className,
+}: DropdownToolbarPropsType) => {
+  const style = useStyles();
+
+  if (!open) return null;
+
+  return (
+    <div className={classNames(style.dropdownContainer, className)}>
+      <Toolbar className={style.toolbarContainer}>{children}</Toolbar>
+    </div>
+  );
+};
+
+type MoreSettingsToolbarItemPropsType = {
+  open: boolean;
+  onChange: (open: boolean) => void;
+  className?: string;
+};
+
+export const MoreSettingsToolbarItem: React.FC<MoreSettingsToolbarItemPropsType> = ({
+  open,
+  onChange,
+  className,
+}: MoreSettingsToolbarItemPropsType) => {
+  const style = useStyles();
+
+  return (
+    <div className={classNames(style.moreSettingsItemContainer, className)}>
+      <IconButton
+        color={(!open && "primary") || undefined}
+        aria-label="more-filter-settings-toggle"
+        onClick={() => onChange(!open)}
+      >
+        <SettingsIcon />
+      </IconButton>
+    </div>
+  );
+};
+
 type IncidentFilterToolbarPropsType = {
   filter: IncidentsFilter;
   onFilterChange: (filter: IncidentsFilter) => void;
@@ -110,6 +175,8 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
   disabled,
 }: IncidentFilterToolbarPropsType) => {
   const style = useStyles();
+  const [dropdownToolbarOpen, setDropdownToolbarOpen] = useState<boolean>(false);
+
   const [autoUpdate, setAutoUpdate] = useState<false | "realtime" | "interval">(
     ENABLE_WEBSOCKETS_SUPPORT ? "realtime" : "interval",
   );
@@ -160,20 +227,6 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
           />
         </ToolbarItem>
 
-        <ToolbarItem name="Auto Update">
-          <ButtonGroupSwitch
-            selected={autoUpdate}
-            options={ENABLE_WEBSOCKETS_SUPPORT ? [false, "realtime", "interval"] : [false, "interval"]}
-            getLabel={(autoUpdate: false | "realtime" | "interval") =>
-              ({ false: "Never", realtime: "Realtime", interval: "Interval" }[autoUpdate || "false"])
-            }
-            getColor={(selected: boolean) => (selected ? "primary" : "default")}
-            onSelect={(autoUpdate: false | "realtime" | "interval") =>
-              (autoUpdate === "realtime" ? ENABLE_WEBSOCKETS_SUPPORT : true) && setAutoUpdate(autoUpdate)
-            }
-          />
-        </ToolbarItem>
-
         {ENABLE_WEBSOCKETS_SUPPORT && (
           <ToolbarItem name="Realtime">
             <Checkbox
@@ -204,7 +257,27 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
             }
           />
         </ToolbarItem>
+
+        <MoreSettingsToolbarItem
+          open={dropdownToolbarOpen}
+          onChange={(open: boolean) => setDropdownToolbarOpen(open)}
+        />
       </Toolbar>
+      <DropdownToolbar open={dropdownToolbarOpen} onClose={() => setDropdownToolbarOpen(false)}>
+        <ToolbarItem name="Auto Update">
+          <ButtonGroupSwitch
+            selected={autoUpdate}
+            options={ENABLE_WEBSOCKETS_SUPPORT ? [false, "realtime", "interval"] : [false, "interval"]}
+            getLabel={(autoUpdate: false | "realtime" | "interval") =>
+              ({ false: "Never", realtime: "Realtime", interval: "Interval" }[autoUpdate || "false"])
+            }
+            getColor={(selected: boolean) => (selected ? "primary" : "default")}
+            onSelect={(autoUpdate: false | "realtime" | "interval") =>
+              (autoUpdate === "realtime" ? ENABLE_WEBSOCKETS_SUPPORT : true) && setAutoUpdate(autoUpdate)
+            }
+          />
+        </ToolbarItem>
+      </DropdownToolbar>
     </div>
   );
 };

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 
 import Button from "@material-ui/core/Button";
 import ButtonGroup from "@material-ui/core/ButtonGroup";
-import Checkbox from "@material-ui/core/Checkbox";
 import Typography from "@material-ui/core/Typography";
 import Toolbar from "@material-ui/core/Toolbar";
 import IconButton from "@material-ui/core/IconButton";
@@ -10,7 +9,7 @@ import SettingsIcon from "@material-ui/icons/Settings";
 
 import { ENABLE_WEBSOCKETS_SUPPORT } from "../../config";
 
-import { IncidentsFilter } from "../../components/incidenttable/FilteredIncidentTable";
+import { IncidentsFilter, AutoUpdate } from "../../components/incidenttable/FilteredIncidentTable";
 
 import TagSelector, { Tag } from "../../components/tagselector";
 import SourceSelector from "../../components/sourceselector";
@@ -177,9 +176,6 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
   const style = useStyles();
   const [dropdownToolbarOpen, setDropdownToolbarOpen] = useState<boolean>(false);
 
-  const [autoUpdate, setAutoUpdate] = useState<false | "realtime" | "interval">(
-    ENABLE_WEBSOCKETS_SUPPORT ? "realtime" : "interval",
-  );
   const [knownSources, setKnownSources] = useState<string[]>([]);
 
   useEffect(() => {
@@ -196,13 +192,33 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
     onFilterChange({ ...filter, showAcked });
   };
 
-  const onRealtimeChange = (realtime: boolean) => {
-    onFilterChange({ ...filter, realtime });
+  const onAutoUpdateChange = (autoUpdate: AutoUpdate) => {
+    onFilterChange({ ...filter, autoUpdate });
   };
 
   const onSourcesChange = (sources: string[] | "AllSources" | undefined) => {
     onFilterChange({ ...filter, sources });
   };
+
+  const autoUpdateOptions: AutoUpdate[] = ENABLE_WEBSOCKETS_SUPPORT
+    ? ["never", "realtime", "interval"]
+    : ["never", "interval"];
+
+  const autoUpdateToolbarItem = (
+    <ToolbarItem name="Auto Update">
+      <ButtonGroupSwitch
+        selected={filter.autoUpdate}
+        options={autoUpdateOptions}
+        getLabel={(autoUpdate: AutoUpdate) =>
+          ({ never: "Never", realtime: "Realtime", interval: "Interval" }[autoUpdate])
+        }
+        getColor={(selected: boolean) => (selected ? "primary" : "default")}
+        onSelect={(autoUpdate: AutoUpdate) =>
+          (autoUpdate === "realtime" ? ENABLE_WEBSOCKETS_SUPPORT : true) && onAutoUpdateChange(autoUpdate)
+        }
+      />
+    </ToolbarItem>
+  );
 
   return (
     <div className={style.root}>
@@ -226,16 +242,6 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
             onSelect={(showAcked: boolean) => onShowAchedChange(showAcked)}
           />
         </ToolbarItem>
-
-        {ENABLE_WEBSOCKETS_SUPPORT && (
-          <ToolbarItem name="Realtime">
-            <Checkbox
-              disabled={disabled}
-              checked={filter.realtime}
-              onClick={() => onRealtimeChange(!filter.realtime)}
-            />
-          </ToolbarItem>
-        )}
 
         <ToolbarItem name="Sources" className={classNames(style.medium)}>
           <SourceSelector
@@ -264,19 +270,7 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
         />
       </Toolbar>
       <DropdownToolbar open={dropdownToolbarOpen} onClose={() => setDropdownToolbarOpen(false)}>
-        <ToolbarItem name="Auto Update">
-          <ButtonGroupSwitch
-            selected={autoUpdate}
-            options={ENABLE_WEBSOCKETS_SUPPORT ? [false, "realtime", "interval"] : [false, "interval"]}
-            getLabel={(autoUpdate: false | "realtime" | "interval") =>
-              ({ false: "Never", realtime: "Realtime", interval: "Interval" }[autoUpdate || "false"])
-            }
-            getColor={(selected: boolean) => (selected ? "primary" : "default")}
-            onSelect={(autoUpdate: false | "realtime" | "interval") =>
-              (autoUpdate === "realtime" ? ENABLE_WEBSOCKETS_SUPPORT : true) && setAutoUpdate(autoUpdate)
-            }
-          />
-        </ToolbarItem>
+        {autoUpdateToolbarItem}
       </DropdownToolbar>
     </div>
   );

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -2,11 +2,9 @@ import React, { useEffect, useState } from "react";
 
 import Button from "@material-ui/core/Button";
 import ButtonGroup from "@material-ui/core/ButtonGroup";
-import Card from "@material-ui/core/Card";
-import CardContent from "@material-ui/core/CardContent";
 import Checkbox from "@material-ui/core/Checkbox";
-import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
+import Toolbar from "@material-ui/core/Toolbar";
 
 import { ENABLE_WEBSOCKETS_SUPPORT } from "../../config";
 
@@ -16,6 +14,61 @@ import TagSelector, { Tag } from "../../components/tagselector";
 import SourceSelector from "../../components/sourceselector";
 
 import api, { IncidentMetadata, SourceSystem } from "../../api";
+
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+
+import classNames from "classnames";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      backgroundColor: theme.palette.background.paper,
+      boxSizing: "border-box",
+      color: theme.palette.text.primary,
+      flexGrow: 1,
+      transition: "0.4s",
+      zIndex: theme.zIndex.drawer + 1,
+      padding: theme.spacing(1),
+    },
+    medium: {
+      flexGrow: 1,
+      minWidth: "15%",
+    },
+    large: { flexGrow: 1, minWidth: "35%" },
+    rightAligned: { paddingRight: theme.spacing(1) },
+    toolbarContainer: {
+      width: "100%",
+      display: "flex",
+      minWidth: "100%",
+      alignItems: "baseline",
+      justifyItems: "center",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      padding: 0,
+    },
+    itemContainer: {
+      display: "flex",
+      flexFlow: "column wrap",
+      margin: theme.spacing(1),
+    },
+  }),
+);
+
+type ToolbarItemPropsType = {
+  name: string;
+  children: React.ReactNode;
+  className?: string;
+};
+
+export const ToolbarItem: React.FC<ToolbarItemPropsType> = ({ name, children, className }: ToolbarItemPropsType) => {
+  const style = useStyles();
+  return (
+    <div className={classNames(style.itemContainer, className)}>
+      <Typography>{name}</Typography>
+      {children}
+    </div>
+  );
+};
 
 type IncidentFilterToolbarPropsType = {
   filter: IncidentsFilter;
@@ -28,6 +81,7 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
   onFilterChange,
   disabled,
 }: IncidentFilterToolbarPropsType) => {
+  const style = useStyles();
   const [knownSources, setKnownSources] = useState<string[]>([]);
 
   useEffect(() => {
@@ -52,80 +106,73 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
     onFilterChange({ ...filter, sources });
   };
 
+  const filterStyle = (show: "open" | "closed" | "both") => {
+    return filter.show === show ? "primary" : undefined;
+  };
+
+  const ackedStyle = (acked: boolean) => {
+    return filter.showAcked === acked ? "primary" : undefined;
+  };
+
   return (
-    <Card>
-      <CardContent>
-        <Typography color="textSecondary" gutterBottom>
-          Incidents filter
-        </Typography>
-        <Grid container xl direction="row" justify="space-evenly" spacing={4}>
-          <Grid item container sm={5} direction="row">
-            <Grid item sm>
-              <Typography>State</Typography>
+    <div className={style.root}>
+      <Toolbar className={style.toolbarContainer}>
+        <ToolbarItem name="State">
+          <ButtonGroup variant="contained" color="default" aria-label="text primary button group">
+            <Button color={filterStyle("open")} onClick={() => onShowChange("open")}>
+              Open
+            </Button>
+            <Button color={filterStyle("closed")} onClick={() => onShowChange("closed")}>
+              Closed
+            </Button>
+            <Button color={filterStyle("both")} onClick={() => onShowChange("both")}>
+              Both
+            </Button>
+          </ButtonGroup>
+        </ToolbarItem>
 
-              <ButtonGroup variant="contained" color="default" aria-label="text primary button group">
-                <Button color={filter.show === "open" ? "primary" : undefined} onClick={() => onShowChange("open")}>
-                  Open
-                </Button>
-                <Button color={filter.show === "closed" ? "primary" : undefined} onClick={() => onShowChange("closed")}>
-                  Closed
-                </Button>
-                <Button color={filter.show === "both" ? "primary" : undefined} onClick={() => onShowChange("both")}>
-                  Both
-                </Button>
-              </ButtonGroup>
-            </Grid>
+        <ToolbarItem name="Acked">
+          <ButtonGroup variant="contained" color="default" aria-label="text primary button group">
+            <Button color={ackedStyle(false)} onClick={() => onShowAchedChange(false)}>
+              Only unacked
+            </Button>
+            <Button color={ackedStyle(true)} onClick={() => onShowAchedChange(true)}>
+              All
+            </Button>
+          </ButtonGroup>
+        </ToolbarItem>
 
-            <Grid item sm>
-              <Typography>Acked</Typography>
-              <ButtonGroup variant="contained" color="default" aria-label="text primary button group">
-                <Button color={!filter.showAcked ? "primary" : undefined} onClick={() => onShowAchedChange(false)}>
-                  Only unacked
-                </Button>
-                <Button color={filter.showAcked ? "primary" : undefined} onClick={() => onShowAchedChange(true)}>
-                  All
-                </Button>
-              </ButtonGroup>
-            </Grid>
-          </Grid>
+        {ENABLE_WEBSOCKETS_SUPPORT && (
+          <ToolbarItem name="Realtime">
+            <Checkbox
+              disabled={disabled}
+              checked={filter.realtime}
+              onClick={() => onRealtimeChange(!filter.realtime)}
+            />
+          </ToolbarItem>
+        )}
 
-          {ENABLE_WEBSOCKETS_SUPPORT && (
-            <Grid item md>
-              <Typography>Realtime</Typography>
-              <Checkbox
-                disabled={disabled}
-                checked={filter.realtime}
-                onClick={() => onRealtimeChange(!filter.realtime)}
-              />
-            </Grid>
-          )}
+        <ToolbarItem name="Sources" className={classNames(style.medium)}>
+          <SourceSelector
+            disabled={disabled}
+            sources={knownSources}
+            onSelectionChange={(selection: string[]) => {
+              onSourcesChange((selection.length !== 0 && selection) || "AllSources");
+            }}
+            defaultSelected={filter.sources === "AllSources" ? [] : filter.sources || []}
+          />
+        </ToolbarItem>
 
-          <Grid item container md direction="row" spacing={4}>
-            <Grid item md>
-              <Typography>Sources to display</Typography>
-              <SourceSelector
-                disabled={disabled}
-                sources={knownSources}
-                onSelectionChange={(selection: string[]) => {
-                  onSourcesChange((selection.length !== 0 && selection) || "AllSources");
-                }}
-                defaultSelected={filter.sources === "AllSources" ? [] : filter.sources || []}
-              />
-            </Grid>
-
-            <Grid item md>
-              <Typography>Tags filter</Typography>
-              <TagSelector
-                disabled={disabled}
-                tags={filter.tags}
-                onSelectionChange={(selection: Tag[]) =>
-                  selection.length !== 0 && selection && onFilterChange({ ...filter, tags: selection })
-                }
-              />
-            </Grid>
-          </Grid>
-        </Grid>
-      </CardContent>
-    </Card>
+        <ToolbarItem name="Tags" className={classNames(style.large, style.rightAligned)}>
+          <TagSelector
+            disabled={disabled}
+            tags={filter.tags}
+            onSelectionChange={(selection: Tag[]) =>
+              selection.length !== 0 && selection && onFilterChange({ ...filter, tags: selection })
+            }
+          />
+        </ToolbarItem>
+      </Toolbar>
+    </div>
   );
 };

--- a/src/components/tagselector/index.tsx
+++ b/src/components/tagselector/index.tsx
@@ -22,6 +22,7 @@ export type TagSelectorPropsType = {
   defaultSelected?: string[];
   allSelected?: boolean;
   disabled?: boolean;
+  className?: string;
 };
 
 export const TagSelector: React.FC<TagSelectorPropsType> = ({
@@ -29,6 +30,7 @@ export const TagSelector: React.FC<TagSelectorPropsType> = ({
   onSelectionChange,
   defaultSelected,
   disabled,
+  className,
 }: TagSelectorPropsType) => {
   const [value, setValue] = useState<string>("");
   const [selectValue, setSelectValue] = useState<string[]>([]);
@@ -88,6 +90,7 @@ export const TagSelector: React.FC<TagSelectorPropsType> = ({
         <TextField
           {...params}
           variant="outlined"
+          className={className}
           label={selectValue ? undefined : "Filter tags"}
           InputProps={{ ...params.InputProps, type: "search" }}
           helperText={(!disabled && "Press enter to add new tag") || undefined}

--- a/src/views/filters/FiltersView.tsx
+++ b/src/views/filters/FiltersView.tsx
@@ -31,7 +31,7 @@ import "../../components/incidenttable/incidenttable.css";
 import { FiltersContext, FiltersContextType, DEFAULT_FILTERS_CONTEXT_VALUE } from "../../components/filters/contexts";
 import { useAlertSnackbar, UseAlertSnackbarResultType } from "../../components/alertsnackbar";
 
-import FilteredIncidentTable from "../../components/incidenttable/FilteredIncidentTable";
+import FilteredIncidentTable, { AutoUpdate } from "../../components/incidenttable/FilteredIncidentTable";
 
 type FiltersTablePropsType = {
   filters: Filter[];
@@ -129,14 +129,14 @@ const FiltersView: React.FC<FiltersViewPropsType> = ({}: FiltersViewPropsType) =
     sourcesById: number[];
     show: "open" | "closed" | "both";
     showAcked: boolean;
-    realtime: boolean;
+    autoUpdate: AutoUpdate;
   }>({
     tags: [],
     sources: "AllSources",
     sourcesById: [],
     show: "open",
     showAcked: true,
-    realtime: ENABLE_WEBSOCKETS_SUPPORT,
+    autoUpdate: ENABLE_WEBSOCKETS_SUPPORT ? "realtime" : "interval",
   });
 
   // The editing filter is the one modified/updated by the Filter Builder

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -13,7 +13,7 @@ type IncidentViewPropsType = {};
 
 const IncidentView: React.FC<IncidentViewPropsType> = ({}: IncidentViewPropsType) => {
   const [filter, setFilter] = useState<IncidentsFilter>({
-    realtime: ENABLE_WEBSOCKETS_SUPPORT,
+    autoUpdate: ENABLE_WEBSOCKETS_SUPPORT ? "realtime" : "interval",
     showAcked: false,
     tags: [],
     sources: "AllSources",


### PR DESCRIPTION
This PR includes some minor improvements to the incidents filter toolbar (rewriting to remove use of Grid), as well as introducing a drop-down that is supposed to be used for useful filter settings that are not needed to be visible at all times.

Currently the only setting in this drop-down is the auto update setting, but there will probably be use for it.

![2020-12-21-002909_1236x176_scrot](https://user-images.githubusercontent.com/1580755/102727058-a4a31680-4323-11eb-924c-c21783a57972.png)

![2020-12-21-002922_1233x271_scrot](https://user-images.githubusercontent.com/1580755/102727057-a076f900-4323-11eb-8c61-c55657d9cbbe.png)

The previous PRs should be merged before this one. 