### PR TITLE
Feat better realtime integration & UI changes

### DIFF
--- a/src/components/incident/styles.tsx
+++ b/src/components/incident/styles.tsx
@@ -43,8 +43,7 @@ export const useStyles = makeStyles((theme: Theme) =>
       color: WHITE,
     },
     tableRow: {
-      // background: theme.palette.success.light,
-      borderLeftWidth: "20px",
+      borderLeftWidth: "10px",
       borderLeftStyle: "solid",
       borderLeftColor: "transparent",
     },

--- a/src/components/incident/styles.tsx
+++ b/src/components/incident/styles.tsx
@@ -1,4 +1,9 @@
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
+
+import yellow from "@material-ui/core/colors/yellow";
+import green from "@material-ui/core/colors/green";
+import red from "@material-ui/core/colors/red";
+
 import { WHITE } from "../../colorscheme";
 
 export const useStyles = makeStyles((theme: Theme) =>
@@ -36,6 +41,21 @@ export const useStyles = makeStyles((theme: Theme) =>
     closedMessage: {
       backgroundColor: theme.palette.success.main,
       color: WHITE,
+    },
+    tableRow: {
+      // background: theme.palette.success.light,
+      borderLeftWidth: "20px",
+      borderLeftStyle: "solid",
+      borderLeftColor: "transparent",
+    },
+    tableRowAcked: {
+      borderLeftColor: yellow["300"],
+    },
+    tableRowClosed: {
+      borderLeftColor: green["300"],
+    },
+    tableRowOpenUnacked: {
+      borderLeftColor: red["300"],
     },
   }),
 );

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -27,6 +27,8 @@ import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 
+import classNames from "classnames";
+
 import {
   useStateWithDynamicDefault,
   toMap,
@@ -157,6 +159,8 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
   isLoading,
   paginationComponent,
 }: MUIIncidentTablePropsType) => {
+  const style = useStyles();
+
   type SelectionState = "SelectedAll" | Set<Incident["pk"]>;
   const [selectedIncidents, setSelectedIncidents] = useState<SelectionState>(new Set<Incident["pk"]>([]));
 
@@ -239,6 +243,14 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
                     style={{
                       cursor: "pointer",
                     }}
+                    className={classNames(
+                      style.tableRow,
+                      incident.open
+                        ? incident.acked
+                          ? style.tableRowAcked
+                          : style.tableRowOpenUnacked
+                        : style.tableRowClosed,
+                    )}
                   >
                     {/* TODO: Not implemented yet */}
                     {false && (

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -211,7 +211,7 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
       <TableContainer component={Paper}>
         <MuiTable size="small" aria-label="incident table">
           <TableHead>
-            <TableRow>
+            <TableRow className={style.tableRow}>
               {/* TODO: Not implemented yet */}
               {false && (
                 <TableCell padding="checkbox" onClick={() => handleToggleSelectAll()}>

--- a/src/services/RealtimeService.ts
+++ b/src/services/RealtimeService.ts
@@ -1,0 +1,116 @@
+import { BACKEND_WS_URL } from "../config";
+
+import { Incident } from "../api";
+
+export type RealtimeServiceConfig = {
+  restartOnFailure?: boolean;
+  fallbackToInterval?: boolean;
+
+  // onIncidentsInitial: called on subscribe, where
+  // a list of all incidents are provided
+  onIncidentsInitial: (incidents: Incident[]) => void;
+
+  onIncidentModified: (incident: Incident) => void;
+  onIncidentRemoved: (incident: Incident) => void;
+  onIncidentAdded: (incident: Incident) => void;
+};
+
+export type RealtimeServiceState = "connecting" | "opened" | "closed";
+// RealtimeService represents all the
+// code required to add WebSockets Realtime
+// incident updates.
+//
+// Authentication works by using the "token" cookie,
+// and that should be set before using this.
+export class RealtimeService {
+  ws: WebSocket | undefined;
+  config: RealtimeServiceConfig;
+  state: RealtimeServiceState;
+
+  retryInterval = 1; // seconds
+  retryIntervalBackoffFactor = 2;
+
+  public constructor({ restartOnFailure = true, fallbackToInterval = true, ...params }: RealtimeServiceConfig) {
+    this.config = { restartOnFailure, fallbackToInterval, ...params };
+    this.state = "closed";
+  }
+
+  public checkConnection() {
+    console.log("checking connection");
+    if (!this.ws || this.ws.readyState == WebSocket.CLOSED) {
+      this.state = "closed";
+      this.connect();
+    }
+  }
+
+  public connect() {
+    let reconnectInterval: ReturnType<typeof setTimeout> | undefined = undefined;
+    if (this.state !== "closed") {
+      console.log("calling connect() when there is existing ws connection. returning");
+      return;
+    }
+
+    this.state = "connecting";
+    this.ws = undefined;
+
+    const ws = new WebSocket(`${BACKEND_WS_URL}/open/`);
+    ws.onmessage = (event: MessageEvent) => {
+      const data = JSON.parse(event.data);
+
+      switch (data.type) {
+        case "modified":
+          const modified: Incident = data.payload;
+          console.log("onmessage: modified", modified);
+          this.config.onIncidentModified(modified);
+          break;
+
+        case "created":
+          const added: Incident = data.payload;
+          console.log("onmessage: created", added);
+          this.config.onIncidentAdded(added);
+          break;
+
+        case "deleted":
+          const removed: Incident = data.payload;
+          console.log("onmessage: deleted", removed);
+          this.config.onIncidentRemoved(removed);
+          break;
+
+        case "subscribed":
+          const incidents: Incident[] = data.start_incidents;
+          console.log("onmessage: subscribed", incidents);
+          this.config.onIncidentsInitial(incidents);
+          break;
+
+        default:
+          console.log(`Unhandled WebSockets message type: ${data.type}`);
+          break;
+      }
+    };
+    ws.onopen = () => {
+      this.state = "opened";
+      this.ws = ws;
+
+      // The "subscribe" action is required to actually
+      // make the server send updates. So we subscribe
+      // to all updates to all incidents here.
+      this.ws.send(JSON.stringify({ action: "subscribe" }));
+
+      this.retryInterval = 1;
+      type ClearTimeoutParams = Parameters<typeof clearTimeout>;
+      clearTimeout(reconnectInterval as ClearTimeoutParams[0]);
+    };
+    ws.onclose = (e: CloseEvent) => {
+      this.state = "closed";
+      console.log(`Realtime socket was closed: ${e.reason}`);
+      reconnectInterval = setTimeout(this.checkConnection, 1000 * this.retryInterval);
+      this.retryInterval *= this.retryIntervalBackoffFactor;
+    };
+
+    // eslint-disable-next-line
+    ws.onerror = (e: any) => {
+      console.error(`Realtime socket got error: ${e.message}`);
+      ws.close();
+    };
+  }
+}


### PR DESCRIPTION
This PR tries to improve the realtime integration in Argus:

1. Seperate out the Websockets logic from incidents table to a seperate service class. 
2. Make incidents that are updated (by user modification or by realtime update) stay visible for 5 seconds before they disappear IF they are supposed to disappear. --- some exceptions that needs to be fixed.
3. Add border to the left-side of the with a color representing the state

Relies on previous PRs, at least #191.