### PR TITLE
Add border to timeslot recurrence and Timeslot UI improvements

### DIFF
--- a/src/components/timeslot/index.tsx
+++ b/src/components/timeslot/index.tsx
@@ -17,7 +17,6 @@ import InputLabel from "@material-ui/core/InputLabel";
 import Grid from "@material-ui/core/Grid";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Checkbox from "@material-ui/core/Checkbox";
-import RemoveIcon from "@material-ui/icons/Remove";
 
 import Spinning from "../spinning";
 import DateFnsUtils from "@date-io/date-fns";
@@ -41,11 +40,40 @@ const useStyles = makeStyles((theme: Theme) =>
     root: {
       flexGrow: 1,
     },
+    grow: {
+      flexGrow: 1,
+    },
     paper: {
       padding: theme.spacing(3),
       textAlign: "center",
       color: theme.palette.text.secondary,
       minWidth: 30,
+    },
+    recurrenceContainer: {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap",
+      padding: theme.spacing(3),
+      borderColor: theme.palette.divider,
+      borderWidth: "2px",
+      borderRadius: "5px",
+      borderStyle: "solid",
+      position: "relative",
+    },
+    dayPickersContainer: {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "nowrap",
+      padding: theme.spacing(3),
+    },
+    timePicker: {
+      padding: theme.spacing(2),
+    },
+    removeWrapper: {
+      right: 0,
+      paddingRight: theme.spacing(3),
+      left: "auto",
+      position: "absolute",
     },
     recurrencePaper: {
       padding: theme.spacing(2),
@@ -94,7 +122,7 @@ export const TimeslotRecurrenceComponent: React.FC<TimeslotRecurrenceComponentPr
   onRemove,
   disabled,
 }: TimeslotRecurrenceComponentPropsType) => {
-  const classes = useStyles();
+  const style = useStyles();
 
   const RemoveRecurrenceButton = makeConfirmationButton({
     title: `Remove recurrence ${recurrence.start}-${recurrence.end}`,
@@ -116,91 +144,82 @@ export const TimeslotRecurrenceComponent: React.FC<TimeslotRecurrenceComponentPr
   const end = !allDay && dateFromTimeOfDayString(recurrence.end);
 
   return (
-    <>
-      <Grid item container lg direction="row" justify="space-between" alignItems="center">
-        <MuiPickersUtilsProvider utils={DateFnsUtils}>
-          <Grid item>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={allDay}
-                  value="checkBox"
-                  color="primary"
-                  inputProps={{
-                    "aria-label": "secondary checkbox",
-                  }}
-                  onClick={() => {
-                    if (allDay) {
-                      onChange(id, { ...DEFAULT_TIMESLOT_RECURRENCE, days: recurrence.days });
-                    } else {
-                      // eslint-disable-next-line
-                      onChange(id, { ...recurrence, all_day: true, start: "", end: "" });
-                    }
-                  }}
-                  disabled={disabled}
-                />
-              }
-              label="All day"
-            />
-          </Grid>
-          <Grid item>
-            <KeyboardTimePicker
-              disabled={allDay || disabled}
-              margin="normal"
-              label="Start time picker"
-              value={start || null}
-              onChange={(date: Date | null) => {
-                if (date) {
-                  onChange(id, { ...recurrence, start: timeOfDayFromDate(date) });
-                } else {
-                  onChange(id, { ...recurrence, start: "" });
-                }
-              }}
-              KeyboardButtonProps={{
-                "aria-label": "change start time",
-              }}
-            />
-          </Grid>
-          <Grid item>
-            <KeyboardTimePicker
-              disabled={allDay || disabled}
-              margin="normal"
-              label="End time picker"
-              value={end || null}
-              KeyboardButtonProps={{
-                "aria-label": "change end time",
-              }}
-              onChange={(date: Date | null) => {
-                if (date) {
-                  onChange(id, { ...recurrence, end: timeOfDayFromDate(date) });
-                } else {
-                  onChange(id, { ...recurrence, end: "" });
-                }
-              }}
-            />
-          </Grid>
-          <Grid item>
-            <RemoveRecurrenceButton
-              variant="text"
-              size="small"
-              className={classes.dangerousButton}
-              startIcon={<RemoveIcon />}
-              onClick={() => handleRemoveRecurrence()}
-              disabled={disabled}
-            >
-              Remove
-            </RemoveRecurrenceButton>
-          </Grid>
-        </MuiPickersUtilsProvider>
-      </Grid>
-      <Grid item>
-        <DaySelector
+    <div className={style.recurrenceContainer}>
+      <div className={style.removeWrapper}>
+        <RemoveRecurrenceButton
+          variant="text"
+          size="small"
+          className={style.dangerousButton}
+          startIcon={<DeleteIcon />}
+          onClick={() => handleRemoveRecurrence()}
           disabled={disabled}
-          selectedDays={recurrence.days}
-          onSelectionChange={handleRecurrenceDaysChange}
-        />
-      </Grid>
-    </>
+        >
+          Remove
+        </RemoveRecurrenceButton>
+      </div>
+      <div className={style.dayPickersContainer}>
+        <MuiPickersUtilsProvider utils={DateFnsUtils}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={allDay}
+                value="checkBox"
+                color="primary"
+                inputProps={{
+                  "aria-label": "secondary checkbox",
+                }}
+                onClick={() => {
+                  if (allDay) {
+                    onChange(id, { ...DEFAULT_TIMESLOT_RECURRENCE, days: recurrence.days });
+                  } else {
+                    // eslint-disable-next-line
+                    onChange(id, { ...recurrence, all_day: true, start: "", end: "" });
+                  }
+                }}
+                disabled={disabled}
+              />
+            }
+            label="All day"
+          />
+          <KeyboardTimePicker
+            className={style.timePicker}
+            disabled={allDay || disabled}
+            margin="normal"
+            label="Start time picker"
+            value={start || null}
+            onChange={(date: Date | null) => {
+              if (date) {
+                onChange(id, { ...recurrence, start: timeOfDayFromDate(date) });
+              } else {
+                onChange(id, { ...recurrence, start: "" });
+              }
+            }}
+            KeyboardButtonProps={{
+              "aria-label": "change start time",
+            }}
+          />
+          <KeyboardTimePicker
+            className={style.timePicker}
+            disabled={allDay || disabled}
+            margin="normal"
+            label="End time picker"
+            value={end || null}
+            KeyboardButtonProps={{
+              "aria-label": "change end time",
+            }}
+            onChange={(date: Date | null) => {
+              if (date) {
+                onChange(id, { ...recurrence, end: timeOfDayFromDate(date) });
+              } else {
+                onChange(id, { ...recurrence, end: "" });
+              }
+            }}
+          />
+          <div className={style.grow} />
+        </MuiPickersUtilsProvider>
+      </div>
+      <DaySelector disabled={disabled} selectedDays={recurrence.days} onSelectionChange={handleRecurrenceDaysChange} />
+    </div>
   );
 };
 

--- a/src/components/timeslotlist/index.tsx
+++ b/src/components/timeslotlist/index.tsx
@@ -16,6 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
+      maxWidth: "900px",
     },
     timeslot: {
       alignItems: "center",

--- a/src/views/timeslot/TimeslotView.tsx
+++ b/src/views/timeslot/TimeslotView.tsx
@@ -1,15 +1,25 @@
 import React from "react";
 import { withRouter } from "react-router-dom";
-import Grid from "@material-ui/core/Grid";
 
 import TimeslotList from "../../components/timeslotlist";
 
+import { createStyles, makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    root: {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+    },
+  }),
+);
+
 const TimeslotView: React.FC = () => {
+  const style = useStyles();
   return (
-    <div className="timeslot-view-container">
-      <Grid container direction="column" justify="space-evenly" alignItems="center">
-        <TimeslotList />
-      </Grid>
+    <div className={style.root}>
+      <TimeslotList />
     </div>
   );
 };


### PR DESCRIPTION
This patch does the following:
 1. Change from using Grid components to using custom flexbox using
    styled components.

    This made it easier to position the UI elements the way I wanted.

 2. Add border to the timeslot recurrence.

    Doing this makes it easier to differentiate between the timeslot
    recurrences.

 3. Move the "remove recurrence" button to the upper right corner