### PR TITLE
Create useAlerts hook and use context in App for alerts snackbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import auth from "./auth";
 import { ThemeProvider } from "@material-ui/core/styles";
 import { MUI_THEME } from "./colorscheme";
 
+import { useAlertSnackbar, AlertsContext } from "./components/alertsnackbar";
 import Header from "./components/header/Header";
 
 // eslint-disable-next-line
@@ -35,6 +36,8 @@ const withHeader = (Component: any) => {
 };
 
 const App: React.SFC = () => {
+  const { incidentSnackbar, displayAlertSnackbar } = useAlertSnackbar();
+
   const history = useHistory();
   api.registerUnauthorizedCallback(() => {
     console.log("Unauthorized response recieved, logging out!");
@@ -45,24 +48,27 @@ const App: React.SFC = () => {
   return (
     <div>
       <ThemeProvider theme={MUI_THEME}>
-        <Switch>
-          <ProtectedRoute exact path="/" component={withHeader(IncidentView)} />
-          <ProtectedRoute path="/incidents/:pk" component={withHeader(IncidentDetailsView)} />
-          <ProtectedRoute exact path="/incidents" component={withHeader(IncidentView)} />
-          <ProtectedRoute path="/notificationprofiles" component={withHeader(NotificationProfileView)} />
-          <ProtectedRoute path="/timeslots" component={withHeader(TimeslotView)} />
-          <ProtectedRoute path="/settings" component={withHeader(SettingsView)} />
-          <ProtectedRoute path="/filters" component={withHeader(FiltersView)} />
-          <Route path="/login" component={LoginView} />
-          <Route
-            path="*"
-            component={() => (
-              <div id="not-found">
-                <h1>404 not found</h1>
-              </div>
-            )}
-          />
-        </Switch>
+        <AlertsContext.Provider value={displayAlertSnackbar}>
+          <Switch>
+            <ProtectedRoute exact path="/" component={withHeader(IncidentView)} />
+            <ProtectedRoute path="/incidents/:pk" component={withHeader(IncidentDetailsView)} />
+            <ProtectedRoute exact path="/incidents" component={withHeader(IncidentView)} />
+            <ProtectedRoute path="/notificationprofiles" component={withHeader(NotificationProfileView)} />
+            <ProtectedRoute path="/timeslots" component={withHeader(TimeslotView)} />
+            <ProtectedRoute path="/settings" component={withHeader(SettingsView)} />
+            <ProtectedRoute path="/filters" component={withHeader(FiltersView)} />
+            <Route path="/login" component={LoginView} />
+            <Route
+              path="*"
+              component={() => (
+                <div id="not-found">
+                  <h1>404 not found</h1>
+                </div>
+              )}
+            />
+          </Switch>
+        </AlertsContext.Provider>
+        {incidentSnackbar}
       </ThemeProvider>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import auth from "./auth";
 import { ThemeProvider } from "@material-ui/core/styles";
 import { MUI_THEME } from "./colorscheme";
 
-import { useAlertSnackbar, AlertsContext } from "./components/alertsnackbar";
+import { AlertSnackbarProvider } from "./components/alertsnackbar";
 import Header from "./components/header/Header";
 
 // eslint-disable-next-line
@@ -36,7 +36,7 @@ const withHeader = (Component: any) => {
 };
 
 const App: React.SFC = () => {
-  const { incidentSnackbar, displayAlertSnackbar } = useAlertSnackbar();
+  // const { incidentSnackbar, displayAlertSnackbar } = useAlertSnackbar();
 
   const history = useHistory();
   api.registerUnauthorizedCallback(() => {
@@ -48,7 +48,7 @@ const App: React.SFC = () => {
   return (
     <div>
       <ThemeProvider theme={MUI_THEME}>
-        <AlertsContext.Provider value={displayAlertSnackbar}>
+        <AlertSnackbarProvider>
           <Switch>
             <ProtectedRoute exact path="/" component={withHeader(IncidentView)} />
             <ProtectedRoute path="/incidents/:pk" component={withHeader(IncidentDetailsView)} />
@@ -67,8 +67,7 @@ const App: React.SFC = () => {
               )}
             />
           </Switch>
-        </AlertsContext.Provider>
-        {incidentSnackbar}
+        </AlertSnackbarProvider>
       </ThemeProvider>
     </div>
   );

--- a/src/components/alertsnackbar/index.tsx
+++ b/src/components/alertsnackbar/index.tsx
@@ -100,6 +100,42 @@ export const useAlertSnackbar = (): UseAlertSnackbarResultType => {
 
 export const AlertsContext = createContext<UseAlertSnackbarResultType["displayAlertSnackbar"]>(() => undefined);
 
+export const AlertSnackbarProvider = ({ children }: { children?: React.ReactNode }) => {
+  const [state, setState] = useState<AlertSnackbarState>({
+    message: "",
+    severity: "info",
+    open: false,
+  });
+
+  const onOpen = () => {
+    setState((state: AlertSnackbarState) => ({ ...state, open: true }));
+  };
+
+  const onClose = () => {
+    setState((state: AlertSnackbarState) => ({ ...state, open: false, keepOpen: false }));
+  };
+
+  const component = <AlertSnackbar onOpen={onOpen} onClose={onClose} {...state} />;
+
+  const displayAlertSnackbar = (message: string, severity?: AlertSnackbarSeverity) => {
+    if (message === state.message && severity === state.severity && state.open) return;
+
+    debuglog(`Displaying message with severity ${severity}: ${message}`);
+    setState((state: AlertSnackbarState) => {
+      return { ...state, open: true, message, severity: severity || "success", keepOpen: severity === "error" };
+    });
+  };
+
+  return (
+    <AlertsContext.Provider value={displayAlertSnackbar}>
+      <>
+        {children}
+        {component}
+      </>
+    </AlertsContext.Provider>
+  );
+};
+
 export const useAlerts = (): typeof displayAlertSnackbar => {
   const displayAlertSnackbar = useContext(AlertsContext);
   return displayAlertSnackbar;

--- a/src/components/alertsnackbar/index.tsx
+++ b/src/components/alertsnackbar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Dispatch, SetStateAction } from "react";
+import React, { useState, useContext, createContext, Dispatch, SetStateAction } from "react";
 
 import Alert from "@material-ui/lab/Alert";
 import MaterialUISnackbar from "@material-ui/core/Snackbar";
@@ -96,6 +96,13 @@ export const useAlertSnackbar = (): UseAlertSnackbarResultType => {
   };
 
   return { incidentSnackbar: component, state, setState, displayAlertSnackbar };
+};
+
+export const AlertsContext = createContext<UseAlertSnackbarResultType["displayAlertSnackbar"]>(() => undefined);
+
+export const useAlerts = (): typeof displayAlertSnackbar => {
+  const displayAlertSnackbar = useContext(AlertsContext);
+  return displayAlertSnackbar;
 };
 
 export default AlertSnackbar;


### PR DESCRIPTION
This PR introduces the useAlerts() hook that can be used anywhere in the app for creating alerts. 