### PR TITLE
Create useFilters hook

### DIFF
--- a/src/api/actions.tsx
+++ b/src/api/actions.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import api, { Filter } from "../api";
 import { InitialStateType, ActionsType } from "../contexts";
-import { deleteFilter as deleteFilterAction } from "../reducers/filter";
+import { deleteFilter as deleteFilterAction, modifyFilter as modifyFilterAction } from "../reducers/filter";
 
 import { AppContext } from "../contexts";
 
@@ -13,8 +13,20 @@ export const deleteFilter = (dispatch: Dispatch, pk: Filter["pk"]): Promise<void
   });
 };
 
+export const modifyFilter = (dispatch: Dispatch, filter: Filter): Promise<Filter> => {
+  const definition = {
+    sourceSystemIds: filter.sourceSystemIds,
+    tags: filter.tags,
+  };
+  return api.putFilter(filter.pk, filter.name, definition).then(() => {
+    dispatch(modifyFilterAction(filter));
+    return filter;
+  });
+};
+
 export type UseFiltersActionType = {
   deleteFilter: (pk: Filter["pk"]) => ReturnType<typeof deleteFilter>;
+  modifyFilter: (filter: Filter) => ReturnType<typeof modifyFilter>;
 };
 
 export function useFilters(): [InitialStateType["filters"], UseFiltersActionType] {
@@ -23,5 +35,11 @@ export function useFilters(): [InitialStateType["filters"], UseFiltersActionType
     dispatch,
   } = useContext(AppContext);
 
-  return [filters, { deleteFilter: (pk: Filter["pk"]) => deleteFilter(dispatch, pk) }];
+  return [
+    filters,
+    {
+      deleteFilter: (pk: Filter["pk"]) => deleteFilter(dispatch, pk),
+      modifyFilter: (filter: Filter) => modifyFilter(dispatch, filter),
+    },
+  ];
 }

--- a/src/api/actions.tsx
+++ b/src/api/actions.tsx
@@ -1,0 +1,27 @@
+import React, { useContext } from "react";
+import api, { Filter } from "../api";
+import { InitialStateType, ActionsType } from "../contexts";
+import { deleteFilter as deleteFilterAction } from "../reducers/filter";
+
+import { AppContext } from "../contexts";
+
+type Dispatch = React.Dispatch<ActionsType>;
+
+export const deleteFilter = (dispatch: Dispatch, pk: Filter["pk"]): Promise<void> => {
+  return api.deleteFilter(pk).then(() => {
+    dispatch(deleteFilterAction(pk));
+  });
+};
+
+export type UseFiltersActionType = {
+  deleteFilter: (pk: Filter["pk"]) => ReturnType<typeof deleteFilter>;
+};
+
+export function useFilters(): [InitialStateType["filters"], UseFiltersActionType] {
+  const {
+    state: { filters },
+    dispatch,
+  } = useContext(AppContext);
+
+  return [filters, { deleteFilter: (pk: Filter["pk"]) => deleteFilter(dispatch, pk) }];
+}

--- a/src/api/actions.tsx
+++ b/src/api/actions.tsx
@@ -1,11 +1,28 @@
 import React, { useContext } from "react";
-import api, { Filter } from "../api";
+import api, { Filter, FilterSuccessResponse } from "../api";
 import { InitialStateType, ActionsType } from "../contexts";
-import { deleteFilter as deleteFilterAction, modifyFilter as modifyFilterAction } from "../reducers/filter";
+import {
+  createFilter as createFilterAction,
+  deleteFilter as deleteFilterAction,
+  modifyFilter as modifyFilterAction,
+} from "../reducers/filter";
 
 import { AppContext } from "../contexts";
 
 type Dispatch = React.Dispatch<ActionsType>;
+
+export const createFilter = (dispatch: Dispatch, filter: Omit<Filter, "pk">): Promise<Filter> => {
+  const definition = {
+    sourceSystemIds: filter.sourceSystemIds,
+    tags: filter.tags,
+  };
+  return api.postFilter(filter.name, definition).then((response: FilterSuccessResponse) => {
+    const { name, pk } = response;
+    const newFilter = { ...filter, name, pk };
+    dispatch(createFilterAction(newFilter));
+    return newFilter;
+  });
+};
 
 export const deleteFilter = (dispatch: Dispatch, pk: Filter["pk"]): Promise<void> => {
   return api.deleteFilter(pk).then(() => {
@@ -25,6 +42,7 @@ export const modifyFilter = (dispatch: Dispatch, filter: Filter): Promise<Filter
 };
 
 export type UseFiltersActionType = {
+  createFilter: (filter: Omit<Filter, "pk">) => ReturnType<typeof createFilter>;
   deleteFilter: (pk: Filter["pk"]) => ReturnType<typeof deleteFilter>;
   modifyFilter: (filter: Filter) => ReturnType<typeof modifyFilter>;
 };
@@ -38,6 +56,7 @@ export function useFilters(): [InitialStateType["filters"], UseFiltersActionType
   return [
     filters,
     {
+      createFilter: (filter: Omit<Filter, "pk">) => createFilter(dispatch, filter),
       deleteFilter: (pk: Filter["pk"]) => deleteFilter(dispatch, pk),
       modifyFilter: (filter: Filter) => modifyFilter(dispatch, filter),
     },

--- a/src/contexts.tsx
+++ b/src/contexts.tsx
@@ -13,7 +13,7 @@ const initialState: InitialStateType = {
   filters: [],
 };
 
-type ActionsType = FilterActions /* | OtherAction | AnotherActoin ... */;
+export type ActionsType = FilterActions /* | OtherAction | AnotherActoin ... */;
 
 const AppContext = createContext<{
   state: InitialStateType;


### PR DESCRIPTION
This PR introduces the useFilters hook that is an easy and clean way to give components access to the filters, and ability to act on them such that any updates are passed to all other components using the global state. 