### PR TITLE
Feat realtime list

### DIFF
--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -250,10 +250,10 @@ export const FiltersDropdownToolbarItem = ({ className }: FiltersDropdownToolbar
           variant="outlined"
           labelId="filter-select"
           id="filter-select"
-          value={selectedFilter?.existingFilter?.pk || -1}
+          value={selectedFilter?.existingFilter?.pk || ""}
           onChange={(event: React.ChangeEvent<{ value: unknown }>) => {
-            const pk: number | -1 = event.target.value as number;
-            if (pk === -1) {
+            const pk: number | "" = event.target.value as number | "";
+            if (pk === "") {
               unsetExistingFilter();
             } else {
               const filter: Filter | undefined = filters.find((filter: Filter) => filter.pk === pk);

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -7,6 +7,7 @@ import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 
 import Button from "@material-ui/core/Button";
 import ButtonGroup from "@material-ui/core/ButtonGroup";
+import Divider from "@material-ui/core/Divider";
 import FormControl from "@material-ui/core/FormControl";
 import FormHelperText from "@material-ui/core/FormHelperText";
 import MenuItem from "@material-ui/core/MenuItem";

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -7,7 +7,6 @@ import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 
 import Button from "@material-ui/core/Button";
 import ButtonGroup from "@material-ui/core/ButtonGroup";
-import Divider from "@material-ui/core/Divider";
 import FormControl from "@material-ui/core/FormControl";
 import FormHelperText from "@material-ui/core/FormHelperText";
 import MenuItem from "@material-ui/core/MenuItem";

--- a/src/components/incident/styles.tsx
+++ b/src/components/incident/styles.tsx
@@ -1,8 +1,10 @@
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 
-import yellow from "@material-ui/core/colors/yellow";
+import grey from "@material-ui/core/colors/grey";
 import green from "@material-ui/core/colors/green";
+import blue from "@material-ui/core/colors/blue";
 import red from "@material-ui/core/colors/red";
+import yellow from "@material-ui/core/colors/yellow";
 
 import { WHITE } from "../../colorscheme";
 
@@ -46,6 +48,15 @@ export const useStyles = makeStyles((theme: Theme) =>
       borderLeftWidth: "10px",
       borderLeftStyle: "solid",
       borderLeftColor: "transparent",
+    },
+    tableRowHeadRealtime: {
+      borderBottomWidth: "5px",
+      borderBottomStyle: "solid",
+      borderBottomColor: blue["300"],
+    },
+    tableRowHeadNormal: {},
+    tableRowLoading: {
+      borderLeftColor: grey["300"],
     },
     tableRowAcked: {
       borderLeftColor: yellow["300"],

--- a/src/components/incidentsprovider.tsx
+++ b/src/components/incidentsprovider.tsx
@@ -23,7 +23,7 @@ const initialIncidentsState: IncidentsStateType = {
   _indexByPk: {},
 };
 
-enum IncidentsType {
+export enum IncidentsType {
   LoadAll = "LOAD_ALL_INCIDENTS",
   ModifyIncident = "MODIFY_INCIDENT",
   RemoveIncident = "REMOVE_INCIDENT",
@@ -144,13 +144,16 @@ export const IncidentsProvider = ({ children }: { children?: React.ReactNode }) 
   return <IncidentsContext.Provider value={{ state, dispatch }}>{children}</IncidentsContext.Provider>;
 };
 
-export const useIncidents = (): [
+type IncidentsDispatch = React.Dispatch<IncidentsActions>;
+
+export const useIncidentsContext = (): [
   IncidentsStateType,
   {
     loadAllIncidents: (incidents: Incident[]) => void;
     modifyIncident: (incident: Incident) => void;
     removeIncident: (pk: Incident["pk"]) => void;
     addIncident: (incident: Incident) => void;
+    dispatch: IncidentsDispatch;
   },
 ] => {
   const { state, dispatch } = useContext(IncidentsContext);
@@ -161,6 +164,7 @@ export const useIncidents = (): [
       modifyIncident: (incident: Incident) => dispatch({ type: IncidentsType.ModifyIncident, payload: incident }),
       removeIncident: (pk: Incident["pk"]) => dispatch({ type: IncidentsType.RemoveIncident, payload: pk }),
       addIncident: (incident: Incident) => dispatch({ type: IncidentsType.AddIncident, payload: incident }),
+      dispatch,
     },
   ];
 };

--- a/src/components/incidentsprovider.tsx
+++ b/src/components/incidentsprovider.tsx
@@ -1,0 +1,168 @@
+import React, { useReducer, useContext, createContext } from "react";
+
+import { Incident } from "../api";
+
+// Store
+import { ActionMap } from "../reducers/common";
+
+type Index = number;
+
+export type IncidentsStateType = {
+  incidents: Incident[];
+
+  // lastModified: number in millis since epoch, of last modification
+  lastModified: { [pk: number]: number };
+
+  // _indexByPk indexes the incident pk to index in incidents
+  _indexByPk: { [pk: number]: Index };
+};
+
+const initialIncidentsState: IncidentsStateType = {
+  incidents: [],
+  lastModified: {},
+  _indexByPk: {},
+};
+
+enum IncidentsType {
+  LoadAll = "LOAD_ALL_INCIDENTS",
+  ModifyIncident = "MODIFY_INCIDENT",
+  RemoveIncident = "REMOVE_INCIDENT",
+  AddIncident = "ADD_INCIDENT",
+}
+
+export type IncidentsPayload = {
+  [IncidentsType.LoadAll]: Incident[];
+  [IncidentsType.ModifyIncident]: Incident;
+  [IncidentsType.RemoveIncident]: Incident["pk"];
+  [IncidentsType.AddIncident]: Incident;
+};
+
+export type IncidentsActions = ActionMap<IncidentsPayload>[keyof ActionMap<IncidentsPayload>];
+export const incidentsReducer = (state: IncidentsStateType, action: IncidentsActions): IncidentsStateType => {
+  const createIncidentsIndex = (incidents: Incident[]): { [pk: number]: Index } => {
+    const mapping: { [pk: number]: Index } = {};
+    incidents.forEach((incident: Incident, index: number) => {
+      mapping[incident.pk] = index;
+    });
+    return mapping;
+  };
+
+  const createUpdatedLM = (pk: Incident["pk"]): { [pk: number]: number } => {
+    return { ...state.lastModified, [pk]: new Date().getTime() };
+  };
+
+  const findIncidentIndex = (pk: Incident["pk"]): Index | null => {
+    if (pk in state._indexByPk) return state._indexByPk[pk];
+    return null;
+  };
+
+  switch (action.type) {
+    case IncidentsType.LoadAll: {
+      const incidents = action.payload;
+      const _indexByPk = createIncidentsIndex(incidents);
+      const millis = new Date().getTime();
+      const lastModified: { [pk: number]: number } = {};
+      incidents.forEach((incident: Incident) => {
+        lastModified[incident.pk] = millis;
+      });
+      return { incidents, lastModified, _indexByPk };
+    }
+
+    case IncidentsType.ModifyIncident: {
+      const incident: Incident = action.payload;
+      const index: Index | null = findIncidentIndex(incident.pk);
+      if (index === null) {
+        // Doesn't exist :(
+        // throw new Error(`Incident ${incident.pk} can't be modified because it doesn't exist`);
+        return incidentsReducer(state, { type: IncidentsType.AddIncident, payload: incident });
+      }
+
+      const { incidents } = state;
+      const newIncidents = incidents.slice(0);
+      newIncidents[index] = incident;
+      return { ...state, incidents: newIncidents, lastModified: createUpdatedLM(incident.pk) };
+    }
+
+    case IncidentsType.RemoveIncident: {
+      const pk: Incident["pk"] = action.payload;
+      const index: Index | null = findIncidentIndex(pk);
+      if (index === null) {
+        // Doesn't exist :(
+        console.warn(`Trying to remove incident ${pk} that doesn't exist, ignoring.`);
+        // throw new Error(`Incident ${pk} can't be removed because it doesn't exist`);
+        return state;
+      }
+
+      const incidents = [...state.incidents];
+      incidents.splice(index, 1);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [pk]: removedIndex, ..._indexByPk } = createIncidentsIndex(incidents);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [pk]: removedLM, ...lastModified } = state.lastModified;
+      // const _indexByPk = createIncidentsIndex(incidents);
+      return { incidents: incidents, lastModified, _indexByPk };
+    }
+
+    case IncidentsType.AddIncident: {
+      const incident: Incident = action.payload;
+      const index: Index | null = findIncidentIndex(incident.pk);
+      if (index !== null) {
+        // Already exists :(
+        // throw new Error(`Incident ${incident} can't be added because it already exists`);
+        console.warn(`Trying to add incident ${incident} that already exists, passing to modify instead.`);
+        return incidentsReducer(state, { type: IncidentsType.ModifyIncident, payload: incident });
+      }
+
+      const incidents = [...state.incidents, incident];
+      const lastModified = createUpdatedLM(incident.pk);
+      const _indexByPk = { ...state._indexByPk, [incident.pk]: state.incidents.length };
+
+      return {
+        incidents,
+        lastModified,
+        _indexByPk,
+      };
+    }
+
+    default:
+      throw new Error(`Unexpected action type ${action}`);
+  }
+};
+
+export const IncidentsContext = createContext<{
+  state: IncidentsStateType;
+  dispatch: React.Dispatch<IncidentsActions>;
+}>({
+  state: initialIncidentsState,
+  dispatch: () => null,
+});
+
+export const IncidentsProvider = ({ children }: { children?: React.ReactNode }) => {
+  const [state, dispatch] = useReducer(incidentsReducer, initialIncidentsState);
+
+  return <IncidentsContext.Provider value={{ state, dispatch }}>{children}</IncidentsContext.Provider>;
+};
+
+export const useIncidents = (): [
+  IncidentsStateType,
+  {
+    loadAllIncidents: (incidents: Incident[]) => void;
+    modifyIncident: (incident: Incident) => void;
+    removeIncident: (pk: Incident["pk"]) => void;
+    addIncident: (incident: Incident) => void;
+  },
+] => {
+  const { state, dispatch } = useContext(IncidentsContext);
+  return [
+    state,
+    {
+      loadAllIncidents: (incidents: Incident[]) => dispatch({ type: IncidentsType.LoadAll, payload: incidents }),
+      modifyIncident: (incident: Incident) => dispatch({ type: IncidentsType.ModifyIncident, payload: incident }),
+      removeIncident: (pk: Incident["pk"]) => dispatch({ type: IncidentsType.RemoveIncident, payload: pk }),
+      addIncident: (incident: Incident) => dispatch({ type: IncidentsType.AddIncident, payload: incident }),
+    },
+  ];
+};
+
+export default IncidentsProvider;

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -23,6 +23,7 @@ import TableCell, { TableCellProps } from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
+import { Skeleton } from "@material-ui/lab";
 
 import classNames from "classnames";
 
@@ -145,6 +146,7 @@ type MUIIncidentTablePropsType = {
   incidents: Incident[];
   onShowDetail: (incide: Incident) => void;
   isLoading?: boolean;
+  isRealtime?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   paginationComponent?: any;
 };
@@ -153,6 +155,7 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
   incidents,
   onShowDetail,
   isLoading,
+  isRealtime = false,
   paginationComponent,
 }: MUIIncidentTablePropsType) => {
   const style = useStyles();
@@ -207,7 +210,9 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
       <TableContainer component={Paper}>
         <MuiTable size="small" aria-label="incident table">
           <TableHead>
-            <TableRow className={style.tableRow}>
+            <TableRow
+              className={classNames(style.tableRow, isRealtime ? style.tableRowHeadRealtime : style.tableRowHeadNormal)}
+            >
               {/* TODO: Not implemented yet */}
               {false && (
                 <TableCell padding="checkbox" onClick={() => handleToggleSelectAll()}>
@@ -222,60 +227,95 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {stableSort<Incident>(incidents, getComparator<IncidentOrderableFields>(order, orderBy))
-              //.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-              .map((incident: Incident) => {
-                const ClickableCell = (props: TableCellProps) => (
-                  <TableCell onClick={(event) => handleRowClick(event, incident)} {...props} />
-                );
-
-                const isSelected = selectedIncidents === "SelectedAll" || selectedIncidents.has(incident.pk);
-
+            {(isLoading &&
+              [0, 1, 2, 3, 4, 5, 6].map((key: number) => {
                 return (
                   <TableRow
                     hover
-                    key={incident.pk}
-                    selected={isSelected}
+                    key={key}
+                    selected={false}
                     style={{
                       cursor: "pointer",
                     }}
-                    className={classNames(
-                      style.tableRow,
-                      incident.open
-                        ? incident.acked
-                          ? style.tableRowAcked
-                          : style.tableRowOpenUnacked
-                        : style.tableRowClosed,
-                    )}
+                    className={classNames(style.tableRow, style.tableRowLoading)}
                   >
-                    {/* TODO: Not implemented yet */}
-                    {false && (
-                      <TableCell padding="checkbox" onClick={() => handleSelectIncident(incident)}>
-                        <Checkbox disabled={isLoading} checked={isSelected} />
-                      </TableCell>
-                    )}
-                    <ClickableCell>{formatTimestamp(incident.start_time)}</ClickableCell>
-                    <ClickableCell component="th" scope="row">
-                      <OpenItem small open={incident.open} />
-                      {/* <TicketItem small ticketUrl={incident.ticket_url} /> */}
-                      <AckedItem small acked={incident.acked} />
-                    </ClickableCell>
-                    <ClickableCell>{incident.source.name}</ClickableCell>
-                    <ClickableCell>{incident.description}</ClickableCell>
                     <TableCell>
-                      <IconButton disabled={isLoading} component={Link} to={`/incidents/${incident.pk}/`}>
-                        <OpenInNewIcon />
-                      </IconButton>
-                      {incident.ticket_url && (
-                        <IconButton disabled={isLoading} href={incident.ticket_url}>
-                          <TicketIcon />
-                        </IconButton>
-                      )}
-                      {/* TODO: Not implementd yet */}
+                      <Skeleton />
+                    </TableCell>
+                    <TableCell component="th" scope="row">
+                      <Skeleton>
+                        <OpenItem small open />
+                      </Skeleton>
+                      <Skeleton>
+                        <AckedItem small acked />
+                      </Skeleton>
+                    </TableCell>
+                    <TableCell>
+                      <Skeleton />
+                    </TableCell>
+                    <TableCell>
+                      <Skeleton />
+                    </TableCell>
+                    <TableCell>
+                      <Skeleton />
                     </TableCell>
                   </TableRow>
                 );
-              })}
+              })) ||
+              stableSort<Incident>(incidents, getComparator<IncidentOrderableFields>(order, orderBy))
+                //.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                .map((incident: Incident) => {
+                  const ClickableCell = (props: TableCellProps) => (
+                    <TableCell onClick={(event) => handleRowClick(event, incident)} {...props} />
+                  );
+
+                  const isSelected = selectedIncidents === "SelectedAll" || selectedIncidents.has(incident.pk);
+
+                  return (
+                    <TableRow
+                      hover
+                      key={incident.pk}
+                      selected={isSelected}
+                      style={{
+                        cursor: "pointer",
+                      }}
+                      className={classNames(
+                        style.tableRow,
+                        incident.open
+                          ? incident.acked
+                            ? style.tableRowAcked
+                            : style.tableRowOpenUnacked
+                          : style.tableRowClosed,
+                      )}
+                    >
+                      {/* TODO: Not implemented yet */}
+                      {false && (
+                        <TableCell padding="checkbox" onClick={() => handleSelectIncident(incident)}>
+                          <Checkbox disabled={isLoading} checked={isSelected} />
+                        </TableCell>
+                      )}
+                      <ClickableCell>{formatTimestamp(incident.start_time)}</ClickableCell>
+                      <ClickableCell component="th" scope="row">
+                        <OpenItem small open={incident.open} />
+                        {/* <TicketItem small ticketUrl={incident.ticket_url} /> */}
+                        <AckedItem small acked={incident.acked} />
+                      </ClickableCell>
+                      <ClickableCell>{incident.source.name}</ClickableCell>
+                      <ClickableCell>{incident.description}</ClickableCell>
+                      <TableCell>
+                        <IconButton disabled={isLoading} component={Link} to={`/incidents/${incident.pk}/`}>
+                          <OpenInNewIcon />
+                        </IconButton>
+                        {incident.ticket_url && (
+                          <IconButton disabled={isLoading} href={incident.ticket_url}>
+                            <TicketIcon />
+                          </IconButton>
+                        )}
+                        {/* TODO: Not implementd yet */}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
           </TableBody>
         </MuiTable>
       </TableContainer>
@@ -488,9 +528,10 @@ const IncidentTable: React.FC<IncidentsProps> = ({
 export type MinimalIncidentTablePropsType = {
   incidents: Incident[];
   isLoading: boolean;
+  isRealtime: boolean;
 };
 
-export const MinimalIncidentTable = ({ incidents, isLoading }: MinimalIncidentTablePropsType) => {
+export const MinimalIncidentTable = ({ incidents, isLoading, isRealtime }: MinimalIncidentTablePropsType) => {
   const [incidentForDetail, setIncidentForDetail] = useState<Incident | undefined>(undefined);
 
   const incidentsDictFromProps = useMemo<Revisioned<Map<Incident["pk"], Incident>>>(
@@ -611,7 +652,12 @@ export const MinimalIncidentTable = ({ incidents, isLoading }: MinimalIncidentTa
           }
           dialogProps={{ maxWidth: "lg", fullWidth: true }}
         />
-        <MUIIncidentTable isLoading={isLoading} incidents={incidentsUpdated} onShowDetail={handleShowDetail} />
+        <MUIIncidentTable
+          isRealtime={isRealtime}
+          isLoading={isLoading}
+          incidents={incidentsUpdated}
+          onShowDetail={handleShowDetail}
+        />
         {incidentSnackbar}
       </div>
     </ClickAwayListener>

--- a/src/components/incidenttable/RealtimeIncidentTable.tsx
+++ b/src/components/incidenttable/RealtimeIncidentTable.tsx
@@ -140,7 +140,7 @@ const RealtimeIncidentTable = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <MinimalIncidentTable isLoading={isLoading} incidents={incidents} />;
+  return <MinimalIncidentTable isRealtime={!isLoadingRealtime} isLoading={isLoading} incidents={incidents} />;
 };
 
 export default RealtimeIncidentTable;

--- a/src/components/incidenttable/RealtimeIncidentTable.tsx
+++ b/src/components/incidenttable/RealtimeIncidentTable.tsx
@@ -69,10 +69,13 @@ const RealtimeIncidentTable = () => {
   const [filterMatcher, setFilterMatcher] = useState<(incident: Incident) => boolean>(() => false);
 
   useEffect(() => {
+    setIsLoading(true);
     // We still load incidents initially using REST, because
     // the websockets implementation in the backend is lacking
     // some features....
-    loadIncidentsFiltered({ showAcked, show, tags, sourcesById, autoUpdate });
+    loadIncidentsFiltered({ showAcked, show, tags, sourcesById, autoUpdate }).then(() => {
+      setIsLoading(false);
+    });
 
     // In order for the websockets callbacks to call the updated filter matching
     // function we need to create a new such function every time the filter changes.
@@ -110,7 +113,7 @@ const RealtimeIncidentTable = () => {
       removeIncident(incident.pk);
     };
 
-    const onIncidentsInitial = (incidents: Incident[]) => {
+    const onIncidentsInitial = (/* incidents: Incident[] */) => {
       // const matchesFilter = incidents.filter((incident: Incident) =>
       //   incidentMatchesFilter(incident, { showAcked, show, tags, sourcesById, autoUpdate }),
       // );
@@ -126,13 +129,14 @@ const RealtimeIncidentTable = () => {
       onIncidentsInitial,
     });
     rts.connect();
-    console.log("created rts and connect()");
+    console.debug("created rts and connect()");
     displayAlert("Realtime enabled", "success");
 
     return () => {
-      console.log("disconnecting rts");
+      console.debug("disconnecting rts");
       displayAlert("Realtime disconnected", "warning");
       rts.disconnect();
+      setIsLoadingRealtime(true);
     };
     // When the websockets backend implementation support taking filters
     // this might be useful:

--- a/src/components/incidenttable/RealtimeIncidentTable.tsx
+++ b/src/components/incidenttable/RealtimeIncidentTable.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from "react";
+
+// Api
+import { Incident, IncidentTag } from "../../api";
+import { RealtimeService } from "../../services/RealtimeService";
+
+// Contexts/Hooks
+import { useSelectedFilter } from "../../components/filterprovider";
+import { useIncidents } from "../../components/incidentsprovider";
+
+// Utils
+import { groupBy } from "../../utils";
+
+// Components
+import { MinimalIncidentTable } from "./IncidentTable";
+import { IncidentsFilter } from "../../components/incidenttable/FilteredIncidentTable";
+import { Tag } from "../../components/tagselector";
+
+// for all different tags "keys", THERE HAS TO BE ONE tag with
+// matching value in incident.tags
+const matchesOnTags = (incident: Incident, tags: Tag[]): boolean => {
+  if (tags.length === 0) {
+    return true;
+  }
+
+  const incidentTagsSet = new Set(incident.tags.map((it: IncidentTag) => it.tag));
+  const tagsGroupedByKey: Map<string, Set<Tag>> = groupBy(tags, (tag: Tag) => tag.key);
+  const returnVal = [...tagsGroupedByKey.keys()].every((tagKey: string) => {
+    const tagsOnKey = tagsGroupedByKey.get(tagKey) || new Set<Tag>();
+    return [...tagsOnKey.values()].some((tag: Tag) => incidentTagsSet.has(tag.original));
+  });
+  return returnVal;
+};
+
+const matchesOnSources = (incident: Incident, sources: number[] | undefined): boolean => {
+  if (sources === undefined || sources.length === 0) {
+    return true;
+  }
+  return sources.some((source: number) => incident.source.pk === source);
+};
+
+const matchesShow = (incident: Incident, show: "open" | "closed" | "both"): boolean => {
+  if (show === "both") return true;
+  return incident.open ? show === "open" : show === "closed";
+};
+
+const matchesAcked = (incident: Incident, showAcked: boolean): boolean => {
+  if (showAcked) return true;
+  return !incident.acked;
+};
+
+type RealtimeIncidentTablePropsType = {};
+
+const RealtimeIncidentTable = () => {
+  const [
+    {
+      filter: { showAcked, show, tags, sourcesById, autoUpdate },
+    },
+    {},
+  ] = useSelectedFilter();
+  const [{ incidents }, { loadAllIncidents, addIncident, modifyIncident, removeIncident }] = useIncidents();
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    setIsLoading(true);
+
+    const incidentMatchesFilter = (incident: Incident, filter: Omit<IncidentsFilter, "sources">): boolean => {
+      const matches =
+        matchesShow(incident, filter.show) &&
+        matchesAcked(incident, filter.showAcked) &&
+        matchesOnTags(incident, filter.tags) &&
+        matchesOnSources(incident, filter.sourcesById);
+      return matches;
+    };
+
+    const onIncidentAdded = (incident: Incident) => {
+      if (incidentMatchesFilter(incident, { showAcked, show, tags, sourcesById, autoUpdate })) {
+        addIncident(incident);
+      }
+    };
+
+    const onIncidentModified = (incident: Incident) => {
+      if (incidentMatchesFilter(incident, { showAcked, show, tags, sourcesById, autoUpdate })) {
+        modifyIncident(incident);
+      } else {
+        removeIncident(incident.pk);
+      }
+    };
+
+    const onIncidentRemoved = (incident: Incident) => {
+      removeIncident(incident.pk);
+    };
+
+    const onIncidentsInitial = (incidents: Incident[]) => {
+      const matchesFilter = incidents.filter((incident: Incident) =>
+        incidentMatchesFilter(incident, { showAcked, show, tags, sourcesById, autoUpdate }),
+      );
+      loadAllIncidents(matchesFilter);
+      setIsLoading(false);
+    };
+
+    const rts = new RealtimeService({
+      onIncidentAdded,
+      onIncidentModified,
+      onIncidentRemoved,
+      onIncidentsInitial,
+    });
+    rts.connect();
+    console.log("created rts and connect()");
+
+    return () => {
+      console.log("disconnecting rts");
+      rts.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showAcked, show, tags, sourcesById, autoUpdate]);
+
+  return <MinimalIncidentTable isLoading={isLoading} incidents={incidents} />;
+};
+
+export default RealtimeIncidentTable;

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -9,8 +9,13 @@ import { IncidentFilterToolbar } from "../../components/incident/IncidentFilterT
 // Context/Hooks
 import { useFilters } from "../../api/actions";
 import { useAlerts } from "../../components/alertsnackbar";
-import SelectedFilterProvider from "../../components/filterprovider"; // TODO: move
+import SelectedFilterProvider, { useSelectedFilter } from "../../components/filterprovider"; // TODO: move
 import IncidentsProvider from "../../components/incidentsprovider"; // TODO: move
+
+const IncidentComponent = () => {
+  const [{ filter }, {}] = useSelectedFilter();
+  return filter.autoUpdate === "realtime" ? <RealtimeIncidentTable /> : <FilteredIncidentTable />;
+};
 
 type IncidentViewPropsType = {};
 
@@ -28,8 +33,10 @@ const IncidentView: React.FC<IncidentViewPropsType> = () => {
   return (
     <div>
       <SelectedFilterProvider>
-        <IncidentFilterToolbar />
-        <FilteredIncidentTable />
+        <IncidentsProvider>
+          <IncidentFilterToolbar />
+          <IncidentComponent />
+        </IncidentsProvider>
       </SelectedFilterProvider>
     </div>
   );

--- a/src/views/incident/IncidentView.tsx
+++ b/src/views/incident/IncidentView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { withRouter } from "react-router-dom";
 
 import FilteredIncidentTable from "../../components/incidenttable/FilteredIncidentTable";
+import RealtimeIncidentTable from "../../components/incidenttable/RealtimeIncidentTable";
 
 import { IncidentFilterToolbar } from "../../components/incident/IncidentFilterToolbar";
 
@@ -9,6 +10,7 @@ import { IncidentFilterToolbar } from "../../components/incident/IncidentFilterT
 import { useFilters } from "../../api/actions";
 import { useAlerts } from "../../components/alertsnackbar";
 import SelectedFilterProvider from "../../components/filterprovider"; // TODO: move
+import IncidentsProvider from "../../components/incidentsprovider"; // TODO: move
 
 type IncidentViewPropsType = {};
 


### PR DESCRIPTION
This PR works on the realtime features. It switches to using contexts for sharing state, and adds some fixes to the RealtimeService, as well as properly handling switching between realtime/interval. +++

Closes #201
Closes #200 
Closes #217

Interacts with #209 by making the decision to not use paging (it's just removed for now). This can probably be undone, because the improved internal architecture makes such changes easier. 

This PR requires rebasing, but because the # of PRs keep increasing I will not spend time doing that everytime I change something. This is based on all previous PRs, even those that are not merged.

NOTE: Not infinitely loading yet, but will be added