### PR TITLE
Feat keep preferences in localstorage

### DIFF
--- a/src/components/filterprovider.tsx
+++ b/src/components/filterprovider.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useContext, createContext } from "react";
+import React, { useEffect, useReducer, useContext, createContext } from "react";
 
 import { IncidentsFilter, AutoUpdate } from "../components/incidenttable/FilteredIncidentTable";
 import { Filter } from "../api";
@@ -6,6 +6,10 @@ import { Tag, originalToTag } from "../components/tagselector";
 
 // Store
 import { ActionMap } from "../reducers/common";
+import { SELECTED_FILTER } from "../localstorageconsts";
+
+// Utils
+import { fromLocalStorageOrDefault, saveToLocalStorage } from "../utils";
 
 export type SelectedFilterStateType = {
   // Optionally selected using drop-down
@@ -146,7 +150,15 @@ export const SelectedFilterContext = createContext<{
 });
 
 export const SelectedFilterProvider = ({ children }: { children?: React.ReactNode }) => {
-  const [state, dispatch] = useReducer(selectedFilterReducer, initialSelectedFilter);
+  const [state, dispatch] = useReducer(
+    selectedFilterReducer,
+    fromLocalStorageOrDefault<SelectedFilterStateType>(SELECTED_FILTER, initialSelectedFilter),
+  );
+
+  useEffect(() => {
+    // Save to local storage
+    saveToLocalStorage<SelectedFilterStateType>(SELECTED_FILTER, state);
+  }, [state]);
 
   return <SelectedFilterContext.Provider value={{ state, dispatch }}>{children}</SelectedFilterContext.Provider>;
 };

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -43,6 +43,10 @@ import api, { Filter, IncidentMetadata, SourceSystem } from "../../api";
 // Config
 import { ENABLE_WEBSOCKETS_SUPPORT } from "../../config";
 
+// Utils
+import { saveToLocalStorage, fromLocalStorageOrDefault } from "../../utils";
+import { DROPDOWN_TOOLBAR } from "../../localstorageconsts";
+
 // Contexts/hooks
 import { useAlerts } from "../../components/alertsnackbar";
 import { useFilters } from "../../api/actions";
@@ -382,7 +386,15 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
   const style = useStyles();
   const [selectedFilter, { setSelectedFilter }] = useSelectedFilter();
 
-  const [dropdownToolbarOpen, setDropdownToolbarOpen] = useState<boolean>(false);
+  const [dropdownToolbarOpen, setDropdownToolbarOpen] = useState<boolean>(
+    // Load from localstorage if possible
+    fromLocalStorageOrDefault(DROPDOWN_TOOLBAR, false, (value: boolean) => value === true || value === false),
+  );
+
+  useEffect(() => {
+    // Save state so that refresh will result in open state if already opened.
+    saveToLocalStorage(DROPDOWN_TOOLBAR, dropdownToolbarOpen);
+  }, [dropdownToolbarOpen]);
 
   const [knownSources, setKnownSources] = useState<string[]>([]);
   const [sourceIdByName, setSourceIdByName] = useState<{ [name: string]: number }>({});

--- a/src/components/incidenttable/FilteredIncidentTable.tsx
+++ b/src/components/incidenttable/FilteredIncidentTable.tsx
@@ -9,8 +9,12 @@ import { DEFAULT_AUTO_REFRESH_INTERVAL } from "../../config";
 // Api
 import api, { Incident, IncidentsFilterOptions, CursorPaginationResponse } from "../../api";
 
+// Utils
+import { saveToLocalStorage, fromLocalStorageOrDefault } from "../../utils";
+
+import { PAGINATION_CURSOR_PAGE_SIZE } from "../../localstorageconsts";
+
 // Contexts/Hooks
-import { useApiPaginatedIncidents } from "../../api/hooks";
 import { useIncidentsContext } from "../../components/incidentsprovider";
 import { useSelectedFilter } from "../../components/filterprovider";
 
@@ -69,7 +73,13 @@ const FilteredIncidentTable = () => {
   const [{ filter }, {}] = useSelectedFilter();
 
   // Keep track of the pagination cursor
-  const [paginationCursor, setPaginationCursor] = useState<PaginationCursor>(DEFAULT_PAGINATION_CURSOR);
+  const [paginationCursor, setPaginationCursor] = useState<PaginationCursor>(
+    // Load page size from local storage if possible
+    {
+      ...DEFAULT_PAGINATION_CURSOR,
+      pageSize: fromLocalStorageOrDefault<number>(PAGINATION_CURSOR_PAGE_SIZE, 25, (pageSize: number) => pageSize > 0),
+    },
+  );
   // We need a virtual cursor in order to retain information
   // about the maxiumum observed amount of pages (we don't get this information from the backend)
   // and the total amount of elements (which we know when we reach the end)
@@ -117,6 +127,11 @@ const FilteredIncidentTable = () => {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    // Save current pagination size to local storage.
+    saveToLocalStorage<PaginationCursor["pageSize"]>(PAGINATION_CURSOR_PAGE_SIZE, paginationCursor.pageSize);
+  }, [paginationCursor]);
 
   const totalElements = useMemo(() => {
     if (!cursors?.next && incidents) {
@@ -205,7 +220,7 @@ const FilteredIncidentTable = () => {
   // Also set the filter matcher
   useEffect(() => {
     setVirtCursor(DEFAULT_VIRT_CURSOR);
-    setPaginationCursor(DEFAULT_PAGINATION_CURSOR);
+    setPaginationCursor((old: PaginationCursor) => ({ ...DEFAULT_PAGINATION_CURSOR, pageSize: old.pageSize }));
   }, [filter]);
 
   const filterMatcher = useMemo(() => {

--- a/src/localstorageconsts.ts
+++ b/src/localstorageconsts.ts
@@ -1,0 +1,6 @@
+// These constants just defined the keys in localstorage
+// Placed here because they are useful to store as constants,
+// but shouldn't ever require user changes
+export const SELECTED_FILTER = "selectedfilter";
+export const PAGINATION_CURSOR_PAGE_SIZE = "paginationcursor";
+export const DROPDOWN_TOOLBAR = "dropdowntoolbar";

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -172,3 +172,30 @@ export function truncateMultilineString(multilineString: string, length: number)
 export const copyTextToClipboard = (text: string) => {
   navigator.clipboard.writeText(text);
 };
+
+type LocalStorageItem<T = { [key: string]: unknown }> = { timestamp: number; value: T };
+
+export function saveToLocalStorage<T>(key: string, data: T): boolean {
+  const exists = !!window.localStorage.getItem(key);
+
+  // Store a timestamp for easy debugging
+  const item: LocalStorageItem<T> = { timestamp: new Date().getTime(), value: data };
+  window.localStorage.setItem(key, JSON.stringify(item));
+  return exists;
+}
+
+export function fromLocalStorageOrDefault<T>(key: string, defaultData: T, validate?: (data: T) => boolean): T {
+  const data = window.localStorage.getItem(key);
+  if (!data) {
+    return defaultData;
+  }
+
+  const { value }: LocalStorageItem<T> = JSON.parse(data);
+
+  if (validate && !validate(value)) {
+    console.warn("LocalStorage item with key", key, "failed to validate:", value);
+    return defaultData;
+  }
+
+  return value;
+}


### PR DESCRIPTION
This PR introduces features that allow for persistence of values in localStorage. It does this by copying parts of contexts/states on every change to them, and then attempting to load from localstorage on initialization. 

Currently implements storage of the following:
1. Page size (for Interval)
2. Selected filter (including open/closed, acked/unacked, and If realtime/interval/never is selected).

It also stores a timestamp along side with the data, which might come in useful during eventual debugging or future improvements.