### PR TITLE
Fix invalid time bug in Safari

### DIFF
--- a/src/components/incident/SignedMessage.tsx
+++ b/src/components/incident/SignedMessage.tsx
@@ -6,6 +6,7 @@ import Grid from "@material-ui/core/Grid";
 import { Timestamp } from "../../api";
 
 import { formatTimestamp } from "../../utils";
+import parseISO from "date-fns/parseISO";
 
 type SignedMessagePropsType = {
   message: string;
@@ -23,7 +24,7 @@ const SignedMessage: React.FC<SignedMessagePropsType> = ({
   content,
   TextComponent,
 }: SignedMessagePropsType) => {
-  const ackDate = new Date(timestamp);
+  const ackDate = parseISO(timestamp);
   const formattedAckDate = formatTimestamp(ackDate);
 
   const Component: React.ComponentType = TextComponent || ListItemText;


### PR DESCRIPTION
Replaces Date() constructor with date-fns' parseISO(). This solution is chosen over converting an invalid timestamp string into a valid one, since the latter involves a more complex refactoring and is less 'universal' in implementation.