### PR TITLE
Incident severity levels

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -388,6 +388,9 @@ class ApiClient {
       if (filter.filter.stateful !== undefined) {
         params.push(`stateful=${filter.filter.stateful}`);
       }
+      if (filter.filter.maxLevel !== undefined) {
+        params.push(`level__lte=${filter.filter.maxLevel}`);
+      }
       if (filter.sourceSystemIds !== undefined) {
         params.push(`source__id__in=${filter.sourceSystemIds.join(",")}`);
       }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -493,6 +493,21 @@ class ApiClient {
 
             console.log("got all filters", resp);
 
+            // Convert null-values to undefined to make page rerender correctly on state update
+            const filter = resp.filter;
+            if (filter.acked === null) {
+              filter.acked = undefined;
+            }
+            if (filter.open === null) {
+              filter.open = undefined;
+            }
+            if (filter.stateful === null) {
+              filter.stateful = undefined;
+            }
+            if (filter.maxLevel === null) {
+              filter.maxLevel = undefined;
+            }
+
             return {
               pk: resp.pk,
               name: resp.name,

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -388,8 +388,8 @@ class ApiClient {
       if (filter.filter.stateful !== undefined) {
         params.push(`stateful=${filter.filter.stateful}`);
       }
-      if (filter.filter.maxLevel !== undefined) {
-        params.push(`level__lte=${filter.filter.maxLevel}`);
+      if (filter.filter.maxlevel !== undefined) {
+        params.push(`level__lte=${filter.filter.maxlevel}`);
       }
       if (filter.sourceSystemIds !== undefined) {
         params.push(`source__id__in=${filter.sourceSystemIds.join(",")}`);
@@ -504,8 +504,8 @@ class ApiClient {
             if (filter.stateful === null) {
               filter.stateful = undefined;
             }
-            if (filter.maxLevel === null) {
-              filter.maxLevel = undefined;
+            if (filter.maxlevel === null) {
+              filter.maxlevel = undefined;
             }
 
             return {
@@ -513,7 +513,7 @@ class ApiClient {
               name: resp.name,
               tags: definition.tags,
               sourceSystemIds: definition.sourceSystemIds,
-              filter: resp.filter,
+              filter: filter,
             };
           },
         ),

--- a/src/api/consts.ts
+++ b/src/api/consts.ts
@@ -1,4 +1,4 @@
-import type { TimeRecurrenceDay, TimeRecurrenceDayName } from "./types.d";
+import type { SeverityLevelName, SeverityLevelNumber, TimeRecurrenceDay, TimeRecurrenceDayName } from "./types.d";
 
 export const TIME_RECURRENCE_DAY_IN_ORDER: TimeRecurrenceDay[] = [1, 2, 3, 4, 5, 6, 7];
 
@@ -20,4 +20,12 @@ export const TimeRecurrenceNameDayMap: Record<TimeRecurrenceDayName, TimeRecurre
   Friday: 5,
   Saturday: 6,
   Sunday: 7,
+};
+
+export const SeverityLevelNumberNameMap: Record<SeverityLevelNumber, SeverityLevelName> = {
+  1: "Critical",
+  2: "High",
+  3: "Moderate",
+  4: "Low",
+  5: "Information",
 };

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -58,7 +58,7 @@ export type FilterContent = {
   open?: boolean;
   acked?: boolean;
   stateful?: boolean;
-  maxLevel?: SeverityLevelNumber;
+  maxlevel?: SeverityLevelNumber;
 };
 
 export type FilterPK = number; // WIP: fix this

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -58,6 +58,7 @@ export type FilterContent = {
   open?: boolean;
   acked?: boolean;
   stateful?: boolean;
+  maxLevel?: SeverityLevelNumber;
 };
 
 export type FilterPK = number; // WIP: fix this

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -119,6 +119,10 @@ export interface NotificationProfile {
  * Incidents
  */
 
+export type SeverityLevelNumber = 1 | 2 | 3 | 4 | 5;
+
+export type SeverityLevelName = "Critical" | "High" | "Moderate" | "Low" | "Information";
+
 export interface SourceSystem {
   pk: number;
   name: string;
@@ -141,6 +145,7 @@ export interface Incident {
   ticket_url: string;
   open: boolean;
   acked: boolean;
+  level: SeverityLevelNumber;
 
   source: SourceSystem;
   source_incident_id: string;

--- a/src/colorscheme.tsx
+++ b/src/colorscheme.tsx
@@ -24,3 +24,5 @@ export const MUI_THEME = createMuiTheme({
 });
 
 export const WHITE = "#FFFFFF";
+export const ORANGE = "#F87217";
+export const YELLOW = "#FCE205";

--- a/src/colorscheme.tsx
+++ b/src/colorscheme.tsx
@@ -24,5 +24,6 @@ export const MUI_THEME = createMuiTheme({
 });
 
 export const WHITE = "#FFFFFF";
-export const ORANGE = "#F87217";
-export const YELLOW = "#FCE205";
+export const RED = "#dc0000";
+export const ORANGE = "#fd8c00";
+export const YELLOW = "#fdc500";

--- a/src/components/filterprovider.tsx
+++ b/src/components/filterprovider.tsx
@@ -41,7 +41,7 @@ const initialSelectedFilter: SelectedFilterStateType = {
     open: true,
     acked: false,
     stateful: undefined,
-    maxLevel: 5,
+    maxlevel: 5,
   },
 
   incidentsFilter: {
@@ -49,7 +49,7 @@ const initialSelectedFilter: SelectedFilterStateType = {
       acked: false,
       open: true,
       stateful: undefined,
-      maxLevel: 5,
+      maxlevel: 5,
     },
     tags: [],
     sourceSystemIds: [],
@@ -102,7 +102,7 @@ function mergedFilterContent(state: FilterContent, selected: SelectedFilterPrope
   nextState.acked = oldOrNew(state.acked, selected?.acked);
   nextState.open = oldOrNew(state.open, selected?.open);
   nextState.stateful = oldOrNew(state.stateful, selected?.stateful);
-  nextState.maxLevel = oldOrNew(state.maxLevel, selected?.maxLevel);
+  nextState.maxlevel = oldOrNew(state.maxlevel, selected?.maxlevel);
   // console.log("state", state, "selected", selected, "next", nextState);
   return nextState;
 }
@@ -140,7 +140,7 @@ export const selectedFilterReducer = (
         filterContent.acked !== state.filterContent.acked ||
         filterContent.open !== state.filterContent.open ||
         filterContent.stateful !== state.filterContent.stateful ||
-        filterContent.maxLevel !== state.filterContent.maxLevel
+        filterContent.maxlevel !== state.filterContent.maxlevel
       ) {
         unset = true;
       } else if (selected.tags && !arrayEquals(selected.tags, state.incidentsFilter.tags)) {

--- a/src/components/filterprovider.tsx
+++ b/src/components/filterprovider.tsx
@@ -41,6 +41,7 @@ const initialSelectedFilter: SelectedFilterStateType = {
     open: true,
     acked: false,
     stateful: undefined,
+    maxLevel: 5,
   },
 
   incidentsFilter: {
@@ -48,6 +49,7 @@ const initialSelectedFilter: SelectedFilterStateType = {
       acked: false,
       open: true,
       stateful: undefined,
+      maxLevel: 5,
     },
     tags: [],
     sourceSystemIds: [],
@@ -100,6 +102,7 @@ function mergedFilterContent(state: FilterContent, selected: SelectedFilterPrope
   nextState.acked = oldOrNew(state.acked, selected?.acked);
   nextState.open = oldOrNew(state.open, selected?.open);
   nextState.stateful = oldOrNew(state.stateful, selected?.stateful);
+  nextState.maxLevel = oldOrNew(state.maxLevel, selected?.maxLevel);
   // console.log("state", state, "selected", selected, "next", nextState);
   return nextState;
 }
@@ -136,7 +139,8 @@ export const selectedFilterReducer = (
       if (
         filterContent.acked !== state.filterContent.acked ||
         filterContent.open !== state.filterContent.open ||
-        filterContent.stateful !== state.filterContent.stateful
+        filterContent.stateful !== state.filterContent.stateful ||
+        filterContent.maxLevel !== state.filterContent.maxLevel
       ) {
         unset = true;
       } else if (selected.tags && !arrayEquals(selected.tags, state.incidentsFilter.tags)) {

--- a/src/components/incident/Chips.tsx
+++ b/src/components/incident/Chips.tsx
@@ -163,7 +163,7 @@ export const LevelItem: React.FC<LevelItemPropsType> = ({ level, small }: LevelI
       size={(small && "small") || undefined}
       variant="outlined"
       className={itemStyle}
-      label={`${level} - ${SeverityLevelNumberNameMap[level]}`}
+      label={small ? SeverityLevelNumberNameMap[level] : `Severity level: ${SeverityLevelNumberNameMap[level]}`}
     />
   );
 };

--- a/src/components/incident/Chips.tsx
+++ b/src/components/incident/Chips.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import Chip from "@material-ui/core/Chip";
-import type { Timestamp } from "../../api/types.d";
+import type { SeverityLevelNumber, Timestamp } from "../../api/types.d";
 
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import { WHITE } from "../../colorscheme";
+import { SeverityLevelNumberNameMap } from "../../api/consts";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -28,6 +29,26 @@ const useStyles = makeStyles((theme: Theme) =>
       color: WHITE,
     },
     ticketed: {
+      background: theme.palette.success.main,
+      color: WHITE,
+    },
+    severityLevel1: {
+      background: theme.palette.warning.main,
+      color: WHITE,
+    },
+    severityLevel2: {
+      background: theme.palette.error.main,
+      color: WHITE,
+    },
+    severityLevel3: {
+      background: theme.palette.secondary.main,
+      color: WHITE,
+    },
+    severityLevel4: {
+      background: theme.palette.success.light,
+      color: WHITE,
+    },
+    severityLevel5: {
       background: theme.palette.success.main,
       color: WHITE,
     },
@@ -112,6 +133,37 @@ export const TicketItem: React.FC<TicketItemPropsType> = ({ ticketUrl, small }: 
       className={ticketUrl ? classes.ticketed : classes.notticketed}
       label={ticketUrl ? `Ticket ${ticketUrl}` : "No ticket"}
       {...chipProps}
+    />
+  );
+};
+
+export type LevelItemPropsType = {
+  level: SeverityLevelNumber;
+  small?: boolean;
+};
+
+export const LevelItem: React.FC<LevelItemPropsType> = ({ level, small }: LevelItemPropsType) => {
+  const classes = useStyles();
+
+  let itemStyle;
+  if (level === 1) {
+    itemStyle = classes.severityLevel1;
+  } else if (level === 2) {
+    itemStyle = classes.severityLevel2;
+  } else if (level === 3) {
+    itemStyle = classes.severityLevel3;
+  } else if (level === 4) {
+    itemStyle = classes.severityLevel4;
+  } else {
+    itemStyle = classes.severityLevel5;
+  }
+
+  return (
+    <Chip
+      size={(small && "small") || undefined}
+      variant="outlined"
+      className={itemStyle}
+      label={`${level} - ${SeverityLevelNumberNameMap[level]}`}
     />
   );
 };

--- a/src/components/incident/Chips.tsx
+++ b/src/components/incident/Chips.tsx
@@ -176,7 +176,11 @@ export const LevelItem: React.FC<LevelItemPropsType> = ({ level, small }: LevelI
       size={(small && "small") || undefined}
       variant="outlined"
       className={className}
-      label={small ? SeverityLevelNumberNameMap[level] : `Severity level: ${SeverityLevelNumberNameMap[level]}`}
+      label={
+        small
+          ? `${level} - ${SeverityLevelNumberNameMap[level]}`
+          : `Severity level: ${level} - ${SeverityLevelNumberNameMap[level]}`
+      }
     />
   );
 };

--- a/src/components/incident/Chips.tsx
+++ b/src/components/incident/Chips.tsx
@@ -4,7 +4,7 @@ import type { SeverityLevelNumber, Timestamp } from "../../api/types.d";
 
 import clsx from "clsx";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
-import { WHITE, YELLOW, ORANGE } from "../../colorscheme";
+import { RED, ORANGE, YELLOW, WHITE } from "../../colorscheme";
 import { SeverityLevelNumberNameMap } from "../../api/consts";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -38,11 +38,11 @@ const useStyles = makeStyles((theme: Theme) =>
       color: WHITE,
     },
     severityLevel2: {
-      background: ORANGE,
+      background: RED,
       color: WHITE,
     },
     severityLevel3: {
-      background: theme.palette.secondary.main,
+      background: ORANGE,
       color: WHITE,
     },
     severityLevel4: {

--- a/src/components/incident/Chips.tsx
+++ b/src/components/incident/Chips.tsx
@@ -3,7 +3,7 @@ import Chip from "@material-ui/core/Chip";
 import type { SeverityLevelNumber, Timestamp } from "../../api/types.d";
 
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
-import { WHITE } from "../../colorscheme";
+import { WHITE, YELLOW, ORANGE } from "../../colorscheme";
 import { SeverityLevelNumberNameMap } from "../../api/consts";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme: Theme) =>
       color: WHITE,
     },
     severityLevel2: {
-      background: theme.palette.error.main,
+      background: ORANGE,
       color: WHITE,
     },
     severityLevel3: {
@@ -45,7 +45,7 @@ const useStyles = makeStyles((theme: Theme) =>
       color: WHITE,
     },
     severityLevel4: {
-      background: theme.palette.success.light,
+      background: YELLOW,
       color: WHITE,
     },
     severityLevel5: {

--- a/src/components/incident/Chips.tsx
+++ b/src/components/incident/Chips.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Chip from "@material-ui/core/Chip";
 import type { SeverityLevelNumber, Timestamp } from "../../api/types.d";
 
+import clsx from "clsx";
 import { makeStyles, Theme, createStyles } from "@material-ui/core/styles";
 import { WHITE, YELLOW, ORANGE } from "../../colorscheme";
 import { SeverityLevelNumberNameMap } from "../../api/consts";
@@ -52,6 +53,12 @@ const useStyles = makeStyles((theme: Theme) =>
       background: theme.palette.success.main,
       color: WHITE,
     },
+    marginLeft: {
+      marginLeft: ".2rem",
+    },
+    marginLeftSmall: {
+      marginLeft: ".1rem",
+    },
   }),
 );
 
@@ -62,11 +69,13 @@ export type OpenItemPropsType = {
 
 export const OpenItem: React.FC<OpenItemPropsType> = ({ open, small }: OpenItemPropsType) => {
   const classes = useStyles();
+  const className = clsx(open ? classes.open : classes.closed, small ? classes.marginLeftSmall : classes.marginLeft);
+
   return (
     <Chip
       size={(small && "small") || undefined}
       variant="outlined"
-      className={open ? classes.open : classes.closed}
+      className={className}
       label={open ? "Open" : "Closed"}
     />
   );
@@ -80,20 +89,18 @@ type AckedItemPropsType = {
 
 export const AckedItem: React.FC<AckedItemPropsType> = ({ acked, expiration, small }: AckedItemPropsType) => {
   const classes = useStyles();
+  const className = clsx(
+    acked ? classes.acknowledged : classes.unacknowledged,
+    small ? classes.marginLeftSmall : classes.marginLeft,
+  );
 
   const expiryDate = expiration && new Date(expiration);
   if (small) {
-    return (
-      <Chip
-        size="small"
-        className={acked ? classes.acknowledged : classes.unacknowledged}
-        label={acked ? "Acked" : "Non-acked"}
-      />
-    );
+    return <Chip size="small" className={className} label={acked ? "Acked" : "Non-acked"} />;
   }
   return (
     <Chip
-      className={acked ? classes.acknowledged : classes.unacknowledged}
+      className={className}
       label={acked ? (expiryDate ? `Acknowledged until ${expiryDate}` : "Acknowledged") : "Unacknowledged"}
     />
   );
@@ -106,6 +113,10 @@ type TicketItemPropsType = {
 
 export const TicketItem: React.FC<TicketItemPropsType> = ({ ticketUrl, small }: TicketItemPropsType) => {
   const classes = useStyles();
+  const className = clsx(
+    ticketUrl ? classes.ticketed : classes.notticketed,
+    small ? classes.marginLeftSmall : classes.marginLeft,
+  );
 
   const chipProps =
     (ticketUrl && {
@@ -120,7 +131,7 @@ export const TicketItem: React.FC<TicketItemPropsType> = ({ ticketUrl, small }: 
       <Chip
         size="small"
         variant="outlined"
-        className={ticketUrl ? classes.ticketed : classes.notticketed}
+        className={className}
         label={ticketUrl ? `Ticket` : "No ticket"}
         {...chipProps}
       />
@@ -130,7 +141,7 @@ export const TicketItem: React.FC<TicketItemPropsType> = ({ ticketUrl, small }: 
   return (
     <Chip
       variant="outlined"
-      className={ticketUrl ? classes.ticketed : classes.notticketed}
+      className={className}
       label={ticketUrl ? `Ticket ${ticketUrl}` : "No ticket"}
       {...chipProps}
     />
@@ -158,11 +169,13 @@ export const LevelItem: React.FC<LevelItemPropsType> = ({ level, small }: LevelI
     itemStyle = classes.severityLevel5;
   }
 
+  const className = clsx(itemStyle, small ? classes.marginLeftSmall : classes.marginLeft);
+
   return (
     <Chip
       size={(small && "small") || undefined}
       variant="outlined"
-      className={itemStyle}
+      className={className}
       label={small ? SeverityLevelNumberNameMap[level] : `Severity level: ${SeverityLevelNumberNameMap[level]}`}
     />
   );

--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -28,7 +28,7 @@ import CenterContainer from "../../components/centercontainer";
 import api from "../../api";
 
 import {
-    Event,
+  Event,
   EventType,
   Incident,
   IncidentTag,
@@ -42,7 +42,7 @@ import { useStyles } from "./styles";
 import ManualClose from "./ManualCloseSignOffAction";
 import CreateAck from "./CreateAckSignOffAction";
 
-import { AckedItem, OpenItem, TicketItem } from "../incident/Chips";
+import { AckedItem, LevelItem, OpenItem, TicketItem } from "../incident/Chips";
 
 // Contexts/Hooks
 import { useAlerts } from "../../components/alertsnackbar";
@@ -339,6 +339,7 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
                   Status
                 </Typography>
                 <CenterContainer>
+                  <LevelItem level={incident.level} />
                   <OpenItem open={incident.open} />
                   <AckedItem acked={incident.acked} expiration={ackExpiryDate} />
                   <TicketItem ticketUrl={incident.ticket_url} />

--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -338,12 +338,18 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
                 <Typography color="textSecondary" gutterBottom>
                   Status
                 </Typography>
-                <CenterContainer>
-                  <LevelItem level={incident.level} />
-                  <OpenItem open={incident.open} />
-                  <AckedItem acked={incident.acked} expiration={ackExpiryDate} />
-                  <TicketItem ticketUrl={incident.ticket_url} />
-                </CenterContainer>
+                <Grid container spacing={1} direction="column">
+                  <Grid item>
+                    <LevelItem level={incident.level} />
+                  </Grid>
+                  <Grid item>
+                    <OpenItem open={incident.open} />
+                    <AckedItem acked={incident.acked} expiration={ackExpiryDate} />
+                  </Grid>
+                  <Grid item>
+                    <TicketItem ticketUrl={incident.ticket_url} />
+                  </Grid>
+                </Grid>
               </CardContent>
             </Card>
           </Grid>

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -528,12 +528,10 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
             <Select
               variant="outlined"
               id="demo-simple-select-outlined"
-              value={
-                selectedFilter?.incidentsFilter?.filter?.maxLevel ? selectedFilter.incidentsFilter.filter.maxLevel : 5
-              }
+              value={optionalOr(selectedFilter?.incidentsFilter?.filter?.maxlevel, 5)}
               onChange={(event: ChangeEvent<{ name?: string; value: unknown }>) => {
-                const maxLevel = event.target.value as SeverityLevelNumber;
-                setSelectedFilter({ filterContent: { maxLevel } });
+                const maxlevel = event.target.value as SeverityLevelNumber;
+                setSelectedFilter({ filterContent: { maxlevel } });
               }}
             >
               {SEVERITY_LEVELS.reverse().map((level: SeverityLevelNumber) => (

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 
 import classNames from "classnames";
 
@@ -34,7 +34,7 @@ import FilterDialog from "../../components/filterdialog";
 import Modal from "../modal/Modal";
 
 // Api
-import type { AutoUpdateMethod, Filter, IncidentMetadata, SourceSystem } from "../../api/types.d";
+import type { AutoUpdateMethod, Filter, IncidentMetadata, SeverityLevelNumber, SourceSystem } from "../../api/types.d";
 import api from "../../api";
 
 // Config
@@ -45,10 +45,11 @@ import { saveToLocalStorage, fromLocalStorageOrDefault, optionalBoolToKey, optio
 import { DROPDOWN_TOOLBAR } from "../../localstorageconsts";
 
 // Contexts/hooks
-import { useAlerts } from "../../components/alertsnackbar";
+import { useAlerts } from "../alertsnackbar";
 import { useFilters } from "../../api/actions";
-import { useSelectedFilter } from "../../components/filterprovider";
+import { useSelectedFilter } from "../filterprovider";
 import { useApiState } from "../../state/hooks";
+import { SeverityLevelNumberNameMap } from "../../api/consts";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -159,7 +160,12 @@ type ToolbarItemPropsType = {
   title: string;
 };
 
-export const ToolbarItem: React.FC<ToolbarItemPropsType> = ({ name, children, className, title }: ToolbarItemPropsType) => {
+export const ToolbarItem: React.FC<ToolbarItemPropsType> = ({
+  name,
+  children,
+  className,
+  title,
+}: ToolbarItemPropsType) => {
   const style = useStyles();
   return (
     <div title={title} className={classNames(style.itemContainer, className)}>
@@ -393,7 +399,7 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
 
   const [dropdownToolbarOpen, setDropdownToolbarOpen] = useState<boolean>(
     // Load from localstorage if possible
-    fromLocalStorageOrDefault(DROPDOWN_TOOLBAR, false, (value: boolean) => value === true || value === false),
+    fromLocalStorageOrDefault(DROPDOWN_TOOLBAR, false, (value: boolean) => value || !value),
   );
 
   useEffect(() => {
@@ -401,9 +407,12 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
     saveToLocalStorage(DROPDOWN_TOOLBAR, dropdownToolbarOpen);
   }, [dropdownToolbarOpen]);
 
+  const SEVERITY_LEVELS: SeverityLevelNumber[] = [1, 2, 3, 4, 5];
+
   const [knownSources, setKnownSources] = useState<string[]>([]);
   const [sourceIdByName, setSourceIdByName] = useState<{ [name: string]: number }>({});
   const [sourceNameById, setSourceNameById] = useState<{ [id: number]: string }>({});
+  const [maxSeverityLevel, setMaxSeverityLevel] = useState<{ level: SeverityLevelNumber }>({ level: 5 });
 
   useEffect(() => {
     // TODO: This could be stored in the global state as well,
@@ -513,6 +522,24 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
             onSelectionChange={(tags: string[]) => setSelectedFilter({ tags })}
             selected={selectedFilter.incidentsFilter?.tags}
           />
+        </ToolbarItem>
+
+        <ToolbarItem title="Max severity level selector" name="Max level" className={classNames(style.medium)}>
+          <FormControl size="small">
+            <Select
+              variant="outlined"
+              id="demo-simple-select-outlined"
+              value={maxSeverityLevel.level}
+              onChange={(event: ChangeEvent<{ name?: string; value: unknown }>) => {
+                const level = event.target.value as SeverityLevelNumber;
+                setMaxSeverityLevel({ level: level });
+              }}
+            >
+              {SEVERITY_LEVELS.reverse().map((level: SeverityLevelNumber) => (
+                <MenuItem key={level} value={level}>{`${level} - ${SeverityLevelNumberNameMap[level]}`}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         </ToolbarItem>
 
         <ToolbarItem title="Filter selector" name="Filter" className={classNames(style.medium)}>

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -412,7 +412,6 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
   const [knownSources, setKnownSources] = useState<string[]>([]);
   const [sourceIdByName, setSourceIdByName] = useState<{ [name: string]: number }>({});
   const [sourceNameById, setSourceNameById] = useState<{ [id: number]: string }>({});
-  const [maxSeverityLevel, setMaxSeverityLevel] = useState<{ level: SeverityLevelNumber }>({ level: 5 });
 
   useEffect(() => {
     // TODO: This could be stored in the global state as well,
@@ -529,10 +528,12 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
             <Select
               variant="outlined"
               id="demo-simple-select-outlined"
-              value={maxSeverityLevel.level}
+              value={
+                selectedFilter?.incidentsFilter?.filter?.maxLevel ? selectedFilter.incidentsFilter.filter.maxLevel : 5
+              }
               onChange={(event: ChangeEvent<{ name?: string; value: unknown }>) => {
-                const level = event.target.value as SeverityLevelNumber;
-                setMaxSeverityLevel({ level: level });
+                const maxLevel = event.target.value as SeverityLevelNumber;
+                setSelectedFilter({ filterContent: { maxLevel } });
               }}
             >
               {SEVERITY_LEVELS.reverse().map((level: SeverityLevelNumber) => (

--- a/src/components/incidenttable/IncidentTable.tsx
+++ b/src/components/incidenttable/IncidentTable.tsx
@@ -26,7 +26,7 @@ import type { Incident } from "../../api/types.d";
 import { formatTimestamp, copyTextToClipboard } from "../../utils";
 
 import { useStyles } from "../incident/styles";
-import { AckedItem, OpenItem } from "../incident/Chips";
+import { AckedItem, LevelItem, OpenItem } from "../incident/Chips";
 import IncidentDetails from "../incident/IncidentDetails";
 
 import Modal from "../../components/modal/Modal";
@@ -147,6 +147,7 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
               {multiSelect && <TableCell></TableCell>}
               <TableCell>Timestamp</TableCell>
               <TableCell>Status</TableCell>
+              <TableCell>Severity level</TableCell>
               <TableCell>Source</TableCell>
               <TableCell>Description</TableCell>
               <TableCell>Actions</TableCell>
@@ -154,7 +155,7 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
           </TableHead>
           <TableBody>
             {(isLoading &&
-              [0, 1, 2, 3, 4, 5, 6].map((key: number) => {
+              [0, 1, 2, 3, 4, 5, 6, 7].map((key: number) => {
                 return (
                   <TableRow
                     hover
@@ -175,6 +176,9 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
                       <Skeleton>
                         <AckedItem small acked />
                       </Skeleton>
+                    </TableCell>
+                    <TableCell>
+                      <Skeleton />
                     </TableCell>
                     <TableCell>
                       <Skeleton />
@@ -224,6 +228,9 @@ const MUIIncidentTable: React.FC<MUIIncidentTablePropsType> = ({
                         <OpenItem small open={incident.open} />
                         {/* <TicketItem small ticketUrl={incident.ticket_url} /> */}
                         <AckedItem small acked={incident.acked} />
+                      </ClickableCell>
+                      <ClickableCell>
+                        <LevelItem small level={incident.level} />
                       </ClickableCell>
                       <ClickableCell>{incident.source.name}</ClickableCell>
                       <ClickableCell>{incident.description}</ClickableCell>


### PR DESCRIPTION
The frontend now shows the severity level for each incident, both in the incident list and in the details dialog. The names and colors of the severity levels is only a suggestion, and can easily be changed later.

Here are some screenshots of the changes that has been made:

## Incident list:
![image](https://user-images.githubusercontent.com/59874198/123627501-60cd2480-d812-11eb-9c23-65bab5dd2f28.png)

## Incident details dialog:
![image](https://user-images.githubusercontent.com/59874198/123627597-7f332000-d812-11eb-9b38-a6ee4c7da746.png)
