### PR TITLE
Correctly marks required fields on the Timeslot-page

### DIFF
--- a/src/components/timeslot/index.tsx
+++ b/src/components/timeslot/index.tsx
@@ -157,6 +157,14 @@ export const TimeslotRecurrenceComponent: React.FC<TimeslotRecurrenceComponentPr
           onChange(id, { ...recurrence, start: timeOfDayFromDate(date) }, false)
           :
           onChange(id, { ...recurrence, end: timeOfDayFromDate(date) }, false)
+      } else if (isStart && isBefore(parse(recurrence.end, 'HH:mm:ss', new Date()), date)) {
+        setStartTimeError(true);
+        setStartTimeHelperText('Must be before end time');
+        onChange(id, { ...recurrence, start: timeOfDayFromDate(date) }, false);
+      } else if (isBefore(date, parse(recurrence.start, 'HH:mm:ss', new Date()))) {
+        setEndTimeError(true);
+        setEndTimeHelperText('Must be after start time');
+        onChange(id, { ...recurrence, end: timeOfDayFromDate(date) }, false);
       } else {
         isStart ? setStartTimeError(false) : setEndTimeError(false);
         isStart ?

--- a/src/components/timeslot/index.tsx
+++ b/src/components/timeslot/index.tsx
@@ -346,6 +346,7 @@ const TimeslotComponent: React.FC<TimeslotPropsType> = ({
                 <TextField
                   id={pk ? `timeslot-${pk}-name-input` : "new-timeslot-name-input"}
                   error={invalidTimeslotName}
+                  helperText={invalidTimeslotName ? "Required" : null}
                   required
                   label="Timeslot name"
                   variant="standard"
@@ -361,6 +362,10 @@ const TimeslotComponent: React.FC<TimeslotPropsType> = ({
                     size="small"
                     className={classes.safeButton}
                     onClick={() => {
+                      if (timeslotName === "") {
+                        setInvalidTimeslotName(true);
+                        return;
+                      }
                       setUpdateLoading(true);
                       onSave(pk, timeslotName, recurrences);
                     }}

--- a/src/components/timeslotlist/index.test.tsx
+++ b/src/components/timeslotlist/index.test.tsx
@@ -339,7 +339,7 @@ describe("TimeslotList: Update existing timeslot", () => {
     expect(newTimeslot2).toBeInTheDocument();
   }, 10000);
 
-  it("fails to update existing timeslot when end time is invalid", async () => {
+  it("fails to update existing timeslot when end time is before start time", async () => {
     const newEndTime = "08:00:00";
 
     // Mock api put request with expected request body
@@ -367,11 +367,29 @@ describe("TimeslotList: Update existing timeslot", () => {
     userEvent.type(endTimePicker, `{selectall}{backspace}${newEndTime.slice(0, 5)}`);
 
     const saveButton = within(existingTimeslot).getByRole("button", { name: /save/i });
-    userEvent.click(saveButton);
+    expect(saveButton).not.toBeEnabled();
 
-    // Expect error message to be shown
-    const errorMessage = await screen.findByText(/failed to put notificationprofile timeslot/i);
-    expect(errorMessage).toBeInTheDocument();
+    // Expect a helper text with correct value to appear
+    expect(within(existingTimeslot).getByText(/must be after start time/i))
+      .toBeInTheDocument();
+  });
+
+  it("fails to update existing timeslot when start time is after end time", async () => {
+    const newStartTime = "14:00:00";
+
+    // Simulate user actions to update existing timeslot with invalid start time
+
+    const existingTimeslot = await screen.findByRole("form", { name: EXISTING_TIMESLOT.name });
+
+    const endTimePicker = within(existingTimeslot).getByRole("textbox", { name: /start time picker/i });
+    userEvent.type(endTimePicker, `{selectall}{backspace}${newStartTime.slice(0, 5)}`);
+
+    const saveButton = within(existingTimeslot).getByRole("button", { name: /save/i });
+    expect(saveButton).not.toBeEnabled();
+
+    // Expect a helper text with correct value to appear
+    expect(within(existingTimeslot).getByText(/must be before end time/i))
+      .toBeInTheDocument();
   });
 
   it("fails to update existing timeslot when name is not provided", async () => {


### PR DESCRIPTION
### Changes made:

- Timeslot name is required in order to make a request to server
- Start time is required in order to make a request to server (unless "All day" is checked)
- End time is required in order to make a request to server (unless "All day" is checked)
- Start time must be before end time in order to make a request to server (unless "All day" is checked)
- Checking "All day" drops all time related restrictions mentioned above


### UI changes that reflect restrictions:

- All required fields are marked with asterisk.
- If provided timeslot name is a blank string, the input field is highlighted in red and helper text appears. 
- If provided start-/end time is left blank, the input field is highlighted in red,  helper text "Required" appears, Save-button is disabled. 
- If provided start-/end time is incomplete, the input field is highlighted in red,  helper text "Invalid" appears, Save-button is disabled. 
- If provided start time is after end time, the input field is highlighted in red,  helper text "Must be before end time" appears, Save-button is disabled. 
- If provided end time is before start time, the input field is highlighted in red,  helper text "Must be after start time" appears, Save-button is disabled. 
- If name is valid, and either both start- and end time are valid, or "All day" is checked, Save-button becomes enabled

Closes #287 