### PR TITLE
Fix incidents table filtering

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -395,19 +395,16 @@ class ApiClient {
       if (SHOW_SEVERITY_LEVELS && filter.filter.maxlevel !== undefined) {
         params.push(`level__lte=${filter.filter.maxlevel}`);
       }
-      if (filter.sourceSystemIds !== undefined) {
-        params.push(`source__id__in=${filter.sourceSystemIds.join(",")}`);
+      if (filter.filter.sourceSystemIds !== undefined) {
+        params.push(`source__id__in=${filter.filter.sourceSystemIds.join(",")}`);
       }
       if (timeframeStart) {
         params.push(`start_time__gte=${formatTimestamp(timeframeStart)}`);
       }
-      // if (filter.sourceSystemNames !== undefined) {
-      //   params.push(`source__name__in=${filter.sourceSystemNames.join(",")}`);
-      // }
-      console.log("filter tags:", filter.tags);
-      // if (filter.tags !== undefined) {
-      //   params.push(`tags=${filter.tags.join(",")}`);
-      // }
+      console.log("filter tags:", filter.filter.tags);
+      if (filter.filter.tags !== undefined) {
+        params.push(`tags=${filter.filter.tags.join(",")}`);
+      }
       if (pageSize !== undefined) {
         params.push(`page_size=${pageSize}`);
       }
@@ -494,10 +491,6 @@ class ApiClient {
       (resps: FilterSuccessResponse[]): Filter[] =>
         resps.map(
           (resp: FilterSuccessResponse): Filter => {
-            // NOTE: When the new "filter" field is used we don't need this
-            // anymore:
-            const definition: FilterString = JSON.parse(resp.filter_string);
-
             console.log("got all filters", resp);
 
             // Convert null-values to undefined to make page rerender correctly on state update
@@ -518,8 +511,6 @@ class ApiClient {
             return {
               pk: resp.pk,
               name: resp.name,
-              tags: definition.tags,
-              sourceSystemIds: definition.sourceSystemIds,
               filter: filter,
             };
           },
@@ -530,11 +521,12 @@ class ApiClient {
 
   public postFilter(filter: Omit<Filter, "pk">): Promise<FilterSuccessResponse> {
     const definition: FilterString = {
-      sourceSystemIds: filter.sourceSystemIds,
-      tags: filter.tags,
+      sourceSystemIds: filter.filter.sourceSystemIds ? filter.filter.sourceSystemIds : [],
+      tags: filter.filter.tags ? filter.filter.tags : [],
     };
 
     const filterString = JSON.stringify(definition) as string;
+    console.log(filterString)
 
     return this.resolveOrReject(
       this.authPost<FilterSuccessResponse, FilterRequest>(`/api/v1/notificationprofiles/filters/`, {
@@ -550,11 +542,12 @@ class ApiClient {
 
   public putFilter(filter: Filter): Promise<FilterSuccessResponse> {
     const definition: FilterString = {
-      sourceSystemIds: filter.sourceSystemIds,
-      tags: filter.tags,
+      sourceSystemIds: filter.filter.sourceSystemIds ? filter.filter.sourceSystemIds : [],
+      tags: filter.filter.tags ? filter.filter.tags : [],
     };
 
     const filterString = JSON.stringify(definition) as string;
+    console.log(filterString)
 
     return this.resolveOrReject(
       this.authPut<FilterSuccessResponse, FilterRequest>(`/api/v1/notificationprofiles/filters/${filter.pk}/`, {

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -51,9 +51,8 @@ export interface Timeslot {
 // using predefied fields, instead of storing a json
 // blob of whatever contents (FilterString).
 export type FilterContent = {
-  // TODO
-  // sourceSystemIds: number[];
-  // tags: string[];
+  sourceSystemIds?: number[];
+  tags?: string[];
 
   open?: boolean;
   acked?: boolean;
@@ -65,11 +64,6 @@ export type FilterPK = number; // WIP: fix this
 export interface Filter {
   pk: FilterPK;
   name: string;
-
-  // TODO: Remove these two fields
-  // when "filter" gets used instead.
-  sourceSystemIds: number[]; // TO_BE_REMOVED
-  tags: string[]; // TO_BE_REMOVED
 
   filter: FilterContent;
 }

--- a/src/components/filteredincidentprovider.tsx
+++ b/src/components/filteredincidentprovider.tsx
@@ -74,8 +74,8 @@ export const matchesFilter = (incident: Incident, filter: Omit<Filter, "pk" | "n
   return (
     matchesShow(incident, filter.filter.open) &&
     matchesAcked(incident, filter.filter.acked) &&
-    matchesOnTags(incident, filter.tags) &&
-    matchesOnSources(incident, filter.sourceSystemIds) &&
+    matchesOnTags(incident, filter.filter.tags) &&
+    matchesOnSources(incident, filter.filter.sourceSystemIds) &&
     matchesMaxlevel(incident, filter.filter.maxlevel)
   );
 };

--- a/src/components/filteredincidentprovider.tsx
+++ b/src/components/filteredincidentprovider.tsx
@@ -15,8 +15,8 @@ import { SHOW_SEVERITY_LEVELS } from "../config";
 
 // for all different tags "keys", THERE HAS TO BE ONE tag with
 // matching value in incident.tags
-export const matchesOnTags = (incident: Incident, tagStrings: string[]): boolean => {
-  if (tagStrings.length === 0) {
+export const matchesOnTags = (incident: Incident, tagStrings: string[] | undefined): boolean => {
+  if (!tagStrings || tagStrings.length === 0) {
     return true;
   }
 

--- a/src/components/filterprovider.tsx
+++ b/src/components/filterprovider.tsx
@@ -13,11 +13,6 @@ export type SelectedFilterStateType = {
   // Optionally selected using drop-down
   existingFilter: Filter | undefined;
 
-  // Additional settings that the user has set
-  // tags: Tag[];
-  tags: string[];
-  sourceSystemIds: number[];
-
   filterContent: FilterContent;
 
   // showAcked: boolean;
@@ -31,9 +26,6 @@ export type SelectedFilterStateType = {
 const initialSelectedFilter: SelectedFilterStateType = {
   existingFilter: undefined,
 
-  tags: [],
-  sourceSystemIds: [],
-
   // showAcked: false,
   // autoUpdate: "realtime", // TODO: this should not be here...
   // show: "open",
@@ -42,6 +34,8 @@ const initialSelectedFilter: SelectedFilterStateType = {
     acked: false,
     stateful: undefined,
     maxlevel: 5,
+    tags: [],
+    sourceSystemIds: [],
   },
 
   incidentsFilter: {
@@ -50,11 +44,9 @@ const initialSelectedFilter: SelectedFilterStateType = {
       open: true,
       stateful: undefined,
       maxlevel: 5,
+      tags: [],
+      sourceSystemIds: [],
     },
-    tags: [],
-    sourceSystemIds: [],
-    // sources: "AllSources",
-    // autoUpdate: "realtime",
   },
 };
 
@@ -174,19 +166,18 @@ export const selectedFilterReducer = (
     case SelectedFilterType.UnsetExistingFilter: {
       const { filterContent } = state;
       const updated = { tags: [], sourceSystemIds: [], filterContent };
-      const incidentsFilter: Omit<Filter, "pk" | "name"> = { ...updated, sourceSystemIds: [], filter: filterContent };
+      const incidentsFilter: Omit<Filter, "pk" | "name"> = {
+        ...updated,
+        filter: filterContent
+      };
       return { ...state, ...updated, existingFilter: undefined, incidentsFilter };
     }
 
     case SelectedFilterType.SetExistingFilter: {
       const existingFilter = action.payload;
       const incidentsFilter: Omit<Filter, "pk" | "name"> = {
-        tags: existingFilter.tags,
-        sourceSystemIds: existingFilter.sourceSystemIds,
         filter: existingFilter.filter,
       };
-
-      // console.log("setting existing", incidentsFilter);
 
       return {
         ...state,
@@ -213,9 +204,7 @@ export const SelectedFilterProvider = ({ children }: { children?: React.ReactNod
   const validateSelectedFilter = (selectedFilter: SelectedFilterStateType) => {
     return !(
       !selectedFilter.filterContent ||
-      !selectedFilter.incidentsFilter ||
-      !selectedFilter.sourceSystemIds ||
-      !selectedFilter.tags
+      !selectedFilter.incidentsFilter
     );
   };
 

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -576,9 +576,13 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
                 const findSourceId = (name: string) => {
                   return sourceIdByName[name];
                 };
-                setSelectedFilter({ sourceSystemIds: sources.map(findSourceId) });
+                setSelectedFilter({
+                  filterContent: {
+                    sourceSystemIds: sources.map(findSourceId).filter(s => s && s !== undefined)
+                  }
+                });
               }}
-              defaultSelected={(selectedFilter.incidentsFilter?.sourceSystemIds || []).map(
+              defaultSelected={(selectedFilter.incidentsFilter?.filter.sourceSystemIds || []).map(
                 (source: number) => sourceNameById[source],
               )}
             />
@@ -587,9 +591,16 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
           <ToolbarItem title="Tags selector" name="Tags" className={`${classNames(style.medium)} lg-xl-tags-selector`}>
             <TagSelector
               disabled={disabled}
-              tags={selectedFilter.incidentsFilter?.tags || []}
-              onSelectionChange={(tags: string[]) => setSelectedFilter({ tags })}
-              selected={selectedFilter.incidentsFilter?.tags}
+              tags={selectedFilter.incidentsFilter.filter.tags || []}
+              onSelectionChange={(tags: string[]) => {
+                const clearedTags: string[] = tags.filter(t => t.split("=").length === 2)
+                setSelectedFilter({
+                  filterContent: {
+                    tags: clearedTags,
+                  }
+                })
+              }}
+              selected={selectedFilter.incidentsFilter?.filter.tags}
             />
           </ToolbarItem>
 
@@ -678,9 +689,15 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
                           const findSourceId = (name: string) => {
                             return sourceIdByName[name];
                           };
-                          setSelectedFilter({ sourceSystemIds: sources.map(findSourceId) });
+                          if (findSourceId) {
+                            setSelectedFilter({
+                              filterContent: {
+                                sourceSystemIds: sources.map(findSourceId).filter(s => s && s !== undefined)
+                              }
+                            });
+                          }
                         }}
-                        defaultSelected={(selectedFilter.incidentsFilter?.sourceSystemIds || []).map(
+                        defaultSelected={(selectedFilter.incidentsFilter?.filter.sourceSystemIds || []).map(
                           (source: number) => sourceNameById[source],
                         )}
                       />
@@ -690,9 +707,16 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
                     <ToolbarItem title="Tags selector" name="Tags" className={classNames(style.medium)}>
                       <TagSelector
                         disabled={disabled}
-                        tags={selectedFilter.incidentsFilter?.tags || []}
-                        onSelectionChange={(tags: string[]) => setSelectedFilter({ tags })}
-                        selected={selectedFilter.incidentsFilter?.tags}
+                        tags={selectedFilter.incidentsFilter.filter.tags || []}
+                        onSelectionChange={(tags: string[]) => {
+                          const clearedTags: string[] = tags.filter(t => t.split("=").length === 2)
+                          setSelectedFilter({
+                            filterContent: {
+                              tags: clearedTags,
+                            }
+                          })
+                        }}
+                        selected={selectedFilter.incidentsFilter.filter.tags}
                       />
                     </ToolbarItem>
                   </Grid>

--- a/src/components/incident/IncidentFilterToolbar.tsx
+++ b/src/components/incident/IncidentFilterToolbar.tsx
@@ -600,7 +600,7 @@ export const IncidentFilterToolbar: React.FC<IncidentFilterToolbarPropsType> = (
                   }
                 })
               }}
-              selected={selectedFilter.incidentsFilter?.filter.tags}
+              selected={selectedFilter.incidentsFilter.filter.tags}
             />
           </ToolbarItem>
 

--- a/src/components/incidenttable/FilteredIncidentTable.tsx
+++ b/src/components/incidenttable/FilteredIncidentTable.tsx
@@ -227,10 +227,15 @@ const FilteredIncidentTable = () => {
   }, [incidentsFilter]);
 
   const filterMatcher = useMemo(() => {
-    const { filter, tags, sourceSystemIds } = incidentsFilter;
+    const {
+      filter,
+    } = incidentsFilter;
     const incidentMatchesFilter = (incident: Incident): boolean => {
       return (
-        matchesFilter(incident, { filter, tags, sourceSystemIds }) &&
+        matchesFilter(incident,
+          {
+            filter,
+          }) &&
         matchesTimeframe(incident, timeframe.timeframeInHours)
       );
     };

--- a/src/components/incidenttable/FilteredIncidentTable.tsx
+++ b/src/components/incidenttable/FilteredIncidentTable.tsx
@@ -103,11 +103,7 @@ const FilteredIncidentTable = () => {
 
   const refresh = useCallback(() => {
     const filter: Omit<Filter, "pk" | "name"> = {
-      filter: incidentsFilter.filter,
-
-      tags: incidentsFilter.tags,
-      // sourceSystemNames: sources === "AllSources" ? undefined : sources,
-      sourceSystemIds: incidentsFilter.sourceSystemIds,
+      filter: incidentsFilter.filter
     };
 
     // Find start of timeframe by removing hours from current datetime

--- a/src/components/tagselector/index.tsx
+++ b/src/components/tagselector/index.tsx
@@ -19,7 +19,7 @@ export const originalToTag = (str: string): Tag => {
 export type TagSelectorPropsType = {
   tags: string[];
   onSelectionChange: (tags: string[]) => void;
-  selected: string[];
+  selected?: string[];
   allSelected?: boolean;
   disabled?: boolean;
   className?: string;

--- a/src/views/incident/IncidentView.test.tsx
+++ b/src/views/incident/IncidentView.test.tsx
@@ -135,10 +135,11 @@ const EXISTING_INCIDENTS: Incident[] = [
 const EXISTING_FILTER: Filter = {
   pk: 10,
   name: 'All',
-  sourceSystemIds: [],
-  tags: [],
 
-  filter: {}
+  filter: {
+    sourceSystemIds: [],
+    tags: [],
+  }
 }
 
 const FILTER_SUCCESS_RES: FilterSuccessResponse[] = [];
@@ -494,6 +495,14 @@ describe('Incidents Table: reflects user interactions with Incidents Filter Tool
       EXISTING_INCIDENTS.filter(i =>
         i.source.name === TESTED_SOURCE_NAME).length;
 
+    // Source systems count
+    const SOURCE_0_COUNT =
+      EXISTING_INCIDENTS.filter(i =>
+        i.source.name === KNOWN_SOURCE_SYSTEMS[0].name).length;
+    const SOURCE_1_COUNT =
+      EXISTING_INCIDENTS.filter(i =>
+        i.source.name === KNOWN_SOURCE_SYSTEMS[1].name).length;
+
     beforeEach(() => {
       // Simulate switching to showing both open and closed incidents (filter update event)
       const bothOpenStatesBtn = screen.getByTitle('Both open and closed incidents');
@@ -503,7 +512,7 @@ describe('Incidents Table: reflects user interactions with Incidents Filter Tool
       userEvent.click(bothAckedStatesButton);
     });
 
-    it("should display no incidents", async () => {
+    it("should silently ignore non-existent source name", async () => {
 
       // Check correct counts after rendering with initial conditions
       expect(await screen.findAllByRole('row'))
@@ -513,19 +522,19 @@ describe('Incidents Table: reflects user interactions with Incidents Filter Tool
       const sourcesSelectorInput = screen.getByPlaceholderText('Source name');
       userEvent.type(sourcesSelectorInput, 'Non-existent Source System{enter}');
 
-      // Wait until table rows are replaced with "No incidents" text
-      await screen.findByText(/no incidents/i);
+      // Expect invalid source name to be removed from the input field
+      expect(sourcesSelectorInput).toBeEmpty();
 
-      // Expect that only header row is rendered
-      expect(screen.getAllByRole('row'))
-        .toHaveLength(1); // header row only
+      // Expect same incident count as before typing a non-existing source name
+      expect(await screen.findAllByRole('row'))
+        .toHaveLength(EXISTING_INCIDENTS.length + 1); // including header row
     });
 
     it("should display only incidents of a given source system", async () => {
 
       // Check correct counts after a preceding user interaction
       expect(await screen.findAllByRole('row'))
-        .toHaveLength(1); // header row only
+        .toHaveLength(EXISTING_INCIDENTS.length + 1); // including header row
 
       // Simulate filtering after an existent source system
       const sourcesSelectorInput = screen.getByPlaceholderText('Source name');
@@ -548,13 +557,12 @@ describe('Incidents Table: reflects user interactions with Incidents Filter Tool
 
       // Simulate filtering after all existent source systems (provide all systems)
       const sourcesSelectorInput = screen.getByPlaceholderText('Source name');
-      KNOWN_SOURCE_SYSTEMS.forEach(source => {
-        userEvent.type(sourcesSelectorInput, `${source.name}{enter}`);
-      });
+
+      // Add remaining (after previous test) source system name in the input field
+      userEvent.type(sourcesSelectorInput, `${KNOWN_SOURCE_SYSTEMS[1].name}{enter}`);
 
       // Wait until table rows appear
       await screen.findAllByRole('row');
-
       // Expect correct counts after filter update event
       expect(screen.getAllByRole('row'))
         .toHaveLength(EXISTING_INCIDENTS.length + 1); // including header row


### PR DESCRIPTION
**Changes made:**

- Tags and Sources are moved to FilterContent. This is both mirroring how backend recognizes filters, as well as facilitates state's recognition of _any_ changes to the filter params. 
- State is now reactive to _any_  valid updates to the sources and tags inputs, and sends a request to the backend on _any_  valid update. Previously, updates to tags and/or sources in the filter toolbar were not triggering requests to the backend, and incidents not matching those updates were "removed" from the table on frontend (but they still occupied space).
- Invalid source- and tag formats provided by the user are silently ignored (they are removed from the input fields and do not trigger table update). Previously, the invalid formats were added to the input field and were triggering the update.

Closes #324, #336