### PR TITLE
Fix blank page due to selecting an old-style filter

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -491,6 +491,10 @@ class ApiClient {
       (resps: FilterSuccessResponse[]): Filter[] =>
         resps.map(
           (resp: FilterSuccessResponse): Filter => {
+            // NOTE: When the new "filter" field is used we don't need this
+            // anymore:
+            const definition: FilterString = JSON.parse(resp.filter_string);
+
             console.log("got all filters", resp);
 
             // Convert null-values to undefined to make page rerender correctly on state update
@@ -507,6 +511,9 @@ class ApiClient {
             if (filter.maxlevel === null) {
               filter.maxlevel = undefined;
             }
+
+            filter.sourceSystemIds = definition.sourceSystemIds
+            filter.tags = definition.tags
 
             return {
               pk: resp.pk,


### PR DESCRIPTION
Incidents page blanked out (or certain fields did not display filter changes) when a user selected an existing filter. This is due to _Filter_ object changes introduced in #346. 
### Changes made:
Fields _sourceSytemIds_ and _tags_ in the _Filter_ object are populated from the _filter string_. 

Closes #349 