### PR TITLE
Make docker compose build more flexible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
       - "8080:8080"
     volumes:
       - .:/app:Z
+    # If npm refuses to start, you may need to use the `node` user instead of
+    # ${UID}. However, on Linux, the latter might cause issues with file
+    # permissions in the `/app` bind-mount.
     user: ${UID}
     environment:
       - CI=true

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends tini build-esse
 # Install argus from configured branch/tag and lock in some dev requirements
 # that aren't part of the regular setup.cfg:
 ARG BRANCH=master
-RUN pip install psycopg2-binary django-extensions python-dotenv git+https://github.com/Uninett/argus@${BRANCH}
+ARG REPO=git+https://github.com/Uninett/argus
+RUN pip install psycopg2-binary django-extensions python-dotenv ${REPO}@${BRANCH}
 
 ENV PORT=8000
 EXPOSE 8000


### PR DESCRIPTION
Mostly this is about the first commit:

Using `${UID}` as the `user` value in `docker-compose.yml` causes problems on macOS (where the mapping/privilege issues don't apply anyway). However, it seems setting it to something other than the image default of `node` might cause problems for the latest node images from Dockerhub (npm just exits with code `243`, producing no output or logs to indicate what went wrong).

