### PR TITLE
Enable the SMS media plugin in docker-compose env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - redis
     environment:
       - TIME_ZONE=Europe/Oslo
-      - DJANGO_SETTINGS_MODULE=argus.site.settings.dockerdev
+      - DJANGO_SETTINGS_MODULE=dockerdev
       - DATABASE_URL=postgresql://argus:HahF9araeKoo@postgres/argus
       - ARGUS_FRONTEND_URL=http://localhost:8080
       - ARGUS_REDIS_SERVER=redis

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -11,6 +11,11 @@ ARG BRANCH=master
 ARG REPO=git+https://github.com/Uninett/argus
 RUN pip install psycopg2-binary django-extensions python-dotenv ${REPO}@${BRANCH}
 
+# Install api backend settings specific to dev deployment of frontend
+RUN mkdir /extrapython
+COPY dockerdev.py /extrapython/
+ENV PYTHONPATH=/extrapython
+
 ENV PORT=8000
 EXPOSE 8000
 COPY docker-entrypoint.sh /

--- a/docker/api/dockerdev.py
+++ b/docker/api/dockerdev.py
@@ -1,0 +1,9 @@
+"""Settings specific to docker-compose deployment of the Argus API container"""
+from argus.site.settings.dockerdev import *
+
+MEDIA_PLUGINS = [
+    "argus.notificationprofile.media.email.EmailNotification",
+    "argus.notificationprofile.media.sms_as_email.SMSNotification",
+]
+
+


### PR DESCRIPTION
This introduces a custom settings file for the API backend service container, so some of the more complex settings of the API server can be manipulated while testing/developing the frontend.

The default settings file used will enable the SMS-as-email plugin, so that developers will be able to work with dumps of production data that contain profiles with phone numbers in them (the API server will crash if there are SMS-enabled profiles present in the database when no SMS plugin is enabled in the settings).