### PR TITLE
Display seconds in all timestamps of the detailed incident view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 
 ### Fixed
 - Fix ARGUS logo clipping part of the name.
+- Add seconds to timestamps in elements of the event feed in detailed incident view

--- a/src/components/incident/SignedMessage.tsx
+++ b/src/components/incident/SignedMessage.tsx
@@ -26,7 +26,7 @@ const SignedMessage: React.FC<SignedMessagePropsType> = ({
   TextComponent,
 }: SignedMessagePropsType) => {
   const ackDate = parseISO(timestamp);
-  const formattedAckDate = formatTimestamp(ackDate);
+  const formattedAckDate = formatTimestamp(ackDate, { withSeconds: true });
 
   const Component: React.ComponentType = TextComponent || ListItemText;
 


### PR DESCRIPTION
### Changes made:
Timestamps in the _Related events_ feed display seconds now.
<img width="405" alt="Screenshot 2022-06-09 at 15 43 28" src="https://user-images.githubusercontent.com/60876078/172861914-36216c8f-4b5a-46cf-b7e1-dfbdeae01c56.png">



Closes #370