### PR TITLE
Upgrade sonarqube-action to v1.2.0

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: SonarQube Scan
-      uses: kitabisa/sonarqube-action@v1.1.1
+      uses: kitabisa/sonarqube-action@v1.2.0
       with:
         host: ${{ secrets.SONARQUBE_HOST }}
         login: ${{ secrets.SONARQUBE_TOKEN }}


### PR DESCRIPTION
We were hit by kitabisa/sonarqube-action#34 - which broke our sonarqube workflow since about July 15 this year.