### PR TITLE
Make phone number optional when creating a notification profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 - Order of events and acknowledgements in feed in detailed incident view. Order is now oldest-first.
 - Made docker-compose build more flexible.
 
+- Make it easier/more obvious to save a profile without a phone number by selecting the option "None".
+- Option "None" is default in the phone number selector in notification profiles.
+
+
 
 ### Added
 - End time to the incident detailed view (for closed incidents only)
@@ -77,5 +81,4 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 - Display of frontend-, backend- and API versions below the incidents table.
 
 
-- Option "None" to the phone number selector in notification profiles.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 ### Changed
 - Logo and favicon
 - Add seconds to timestamps in elements of the event feed in detailed incident view
+
+### Added
+- Option "None" to the phone number selector in notification profiles.

--- a/NOTES.md
+++ b/NOTES.md
@@ -18,16 +18,15 @@ This file documents changes to Argus-frontend that are important for the users t
 - Logo and favicon
 - Add seconds to timestamps in elements of the event feed in detailed incident view
 
-- Option "None" is default in the phone number selector in notification profiles.
-
 - Order of events and acknowledgements in feed in detailed incident view. Order is now oldest-first.
 
+- Make it easier/more obvious to save a profile without a phone number by selecting the option "None".
+- Option "None" is default in the phone number selector in notification profiles.
 
 
 ### Added
 - End time to the incident detailed view (for closed incidents only)
 
-- Option "None" to the phone number selector in notification profiles.
 
 
 ## [v1.5.4]

--- a/NOTES.md
+++ b/NOTES.md
@@ -6,3 +6,7 @@ This file documents changes to Argus-frontend that are important for the users t
 ### Changed
 - Logo to the one with eye and text (without TV-frame)
 - Favicon to the one with eye-only
+- Option "None" is default in the phone number selector in notification profiles.
+
+### Added
+- Option "None" to the phone number selector in notification profiles.

--- a/src/components/notificationprofile/NotificationProfileCard.test.tsx
+++ b/src/components/notificationprofile/NotificationProfileCard.test.tsx
@@ -33,7 +33,7 @@ const newProfile: NotificationProfileKeyed = {
   media: ["EM", "SM"],
   active: true,
   // eslint-disable-next-line @typescript-eslint/camelcase
-  phone_number: 1,
+  phone_number: 0,
 };
 
 const timeslots: Timeslot[] = [
@@ -155,9 +155,14 @@ describe("Rendering existing profile", () => {
 
     userEvent.click(phoneNumberSelector);
 
-    const phoneNumberOption1 = screen.getByRole("option", { name: phoneNumbers[0].phone_number });
-    const phoneNumberOption2 = screen.getByRole("option", { name: phoneNumbers[1].phone_number });
+    // Expect length to be: all saved phone numbers plus "None"
+    expect(screen.getAllByRole("option")).toHaveLength(phoneNumbers.length + 1);
 
+    const phoneNumberOptionNone = screen.getByRole("option", {name: /none/i});
+    const phoneNumberOption1 = screen.getByRole("option", {name: phoneNumbers[0].phone_number});
+    const phoneNumberOption2 = screen.getByRole("option", {name: phoneNumbers[1].phone_number});
+
+    expect(phoneNumberOptionNone).toBeInTheDocument();
     expect(phoneNumberOption1).toBeInTheDocument();
     expect(phoneNumberOption2).toBeInTheDocument();
   });
@@ -235,14 +240,24 @@ describe("Rendering new profile", () => {
   });
 
   it("renders the phone number selector correctly", () => {
-    const phoneNumberSelector = screen.getByRole("button", { name: phoneNumbers[0].phone_number });
+    const phoneNumberSelector = screen.getByTestId("phone-number-selector");
     expect(phoneNumberSelector).toBeInTheDocument();
+    // Default phone number value is "None" with a display value of ""
+    expect(phoneNumberSelector).toHaveTextContent(/^/);
 
-    userEvent.click(phoneNumberSelector);
 
-    const phoneNumberOption1 = screen.getByRole("option", { name: phoneNumbers[0].phone_number });
-    const phoneNumberOption2 = screen.getByRole("option", { name: phoneNumbers[1].phone_number });
+    // User opens dropdown with options
+    userEvent.click(within(phoneNumberSelector).getByRole("button"));
 
+
+    // Expect length to be: all saved phone numbers plus "None"
+    expect(screen.getAllByRole("option")).toHaveLength(phoneNumbers.length + 1);
+
+    const phoneNumberOptionNone = screen.getByRole("option", {name: /none/i});
+    const phoneNumberOption1 = screen.getByRole("option", {name: phoneNumbers[0].phone_number});
+    const phoneNumberOption2 = screen.getByRole("option", {name: phoneNumbers[1].phone_number});
+
+    expect(phoneNumberOptionNone).toBeInTheDocument();
     expect(phoneNumberOption1).toBeInTheDocument();
     expect(phoneNumberOption2).toBeInTheDocument();
   });

--- a/src/components/notificationprofile/NotificationProfileCard.tsx
+++ b/src/components/notificationprofile/NotificationProfileCard.tsx
@@ -244,6 +244,7 @@ const NotificationProfileCard = ({
                 className={style.phoneNumberSelect}
                 value={profileState.phone_number ? profileState.phone_number : ""}
                 onChange={handlePhoneNumberChange}
+                data-testid="phone-number-selector"
               >
                 <MenuItem value={""}>
                   <em>None</em>

--- a/src/components/notificationprofile/NotificationProfileCard.tsx
+++ b/src/components/notificationprofile/NotificationProfileCard.tsx
@@ -245,6 +245,9 @@ const NotificationProfileCard = ({
                 value={profileState.phone_number ? profileState.phone_number : ""}
                 onChange={handlePhoneNumberChange}
               >
+                <MenuItem value={""}>
+                  <em>None</em>
+                </MenuItem>
                 {phoneNumbers.map((phoneNumber: PhoneNumber) => (
                   <MenuItem key={phoneNumber.pk} value={phoneNumber.pk}>
                     {phoneNumber.phone_number}

--- a/src/components/notificationprofile/NotificationProfileList.tsx
+++ b/src/components/notificationprofile/NotificationProfileList.tsx
@@ -220,7 +220,7 @@ const NotificationProfileList = () => {
     filters: [],
     media: [],
     // eslint-disable-next-line @typescript-eslint/camelcase
-    phone_number: phoneNumbers.length > 0 ? phoneNumbers[0].pk : 0,
+    phone_number: 0,
     active: true,
   };
 


### PR DESCRIPTION
## Changes made:

- Added option "None" to the _Phone Number selector_ in notification profiles.
- Made option "None" a default one when creating a new notification profile.

Closes #404 