### PR TITLE
Make phonenumber component prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 
 ### Fixed
 - Fix ARGUS logo clipping part of the name.
-- Fix a bug in Timeslot's time pickers where changing start-/end time via icon, leads to wrong values being registered, misleading error text being displayed, and "Save"-button being disabled 
+- Fix a bug in Timeslot's time pickers where changing start-/end time via icon, leads to wrong values being registered, misleading error text being displayed, and "Save"-button being disabled
 - Fix a bug in Timeslot's time pickers where typing invalid values for both start- and end time (both input fields display error text), disrupts further changes (incl. corrections) of those time values
-- Fix a bug in Timeslot's time pickers where error text is not always removed and "Save"-button is disabled, even after user has provided valid and non-conflicting values (time range where start time is before end time) 
+- Fix a bug in Timeslot's time pickers where error text is not always removed and "Save"-button is disabled, even after user has provided valid and non-conflicting values (time range where start time is before end time)
 - Fix bug where incidents count was messed up due to user switching between table pages too rapidly
 
 - Labeling of "Unacked" chips and buttons is now consistent.
@@ -20,6 +20,8 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 - Add seconds to timestamps in elements of the event feed in detailed incident view
 - Order of events and acknowledgements in feed in detailed incident view. Order is now oldest-first.
 - Made docker-compose build more flexible.
+
+- Updated the phonenumber component to have prettier and more sensible css.
 
 
 ### Added

--- a/src/components/phonenumber/index.tsx
+++ b/src/components/phonenumber/index.tsx
@@ -18,7 +18,6 @@ import { WHITE } from "../../colorscheme";
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     paper: {
-      textAlign: "center",
       color: theme.palette.text.secondary,
       minWidth: 30,
     },

--- a/src/components/phonenumber/index.tsx
+++ b/src/components/phonenumber/index.tsx
@@ -38,6 +38,7 @@ const useStyles = makeStyles((theme: Theme) =>
     form: {
       alignItems: "center",
       display: "flex",
+      justifyContent: "space-between",
     },
   }),
 );

--- a/src/components/phonenumber/index.tsx
+++ b/src/components/phonenumber/index.tsx
@@ -34,7 +34,11 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     phoneField: {
       margin: theme.spacing(),
-    }
+    },
+    form: {
+      alignItems: "center",
+      display: "flex",
+    },
   }),
 );
 
@@ -85,7 +89,7 @@ const PhoneNumberComponent: React.FC<PhoneNumberPropsType> = ({
   return (
     <div key={pk}>
       <Paper className={classes.paper}>
-        <form noValidate autoComplete="off">
+        <form className={classes.form} noValidate autoComplete="off">
           <TextField
             error={invalidPhoneNumber}
             required

--- a/src/components/phonenumber/index.tsx
+++ b/src/components/phonenumber/index.tsx
@@ -34,13 +34,6 @@ const useStyles = makeStyles((theme: Theme) =>
       background: theme.palette.primary.main,
       color: WHITE,
     },
-    phoneNumber: {
-      alignItems: "center",
-      padding: theme.spacing(3),
-    },
-    createDeleteButtonGroup: {
-      margin: theme.spacing(1),
-    },
   }),
 );
 

--- a/src/components/phonenumber/index.tsx
+++ b/src/components/phonenumber/index.tsx
@@ -29,11 +29,16 @@ const useStyles = makeStyles((theme: Theme) =>
     dangerousButton: {
       background: theme.palette.warning.main,
       color: WHITE,
+      margin: theme.spacing(),
     },
     saveButton: {
       background: theme.palette.primary.main,
       color: WHITE,
+      margin: theme.spacing(),
     },
+    phoneField: {
+      margin: theme.spacing(),
+    }
   }),
 );
 
@@ -90,6 +95,7 @@ const PhoneNumberComponent: React.FC<PhoneNumberPropsType> = ({
             required
             label="Phone number"
             variant="standard"
+            className={classes.phoneField}
             value={phoneNumber}
             onChange={onPhoneNumberChange}
           />

--- a/src/components/phonenumber/index.tsx
+++ b/src/components/phonenumber/index.tsx
@@ -21,7 +21,6 @@ const useStyles = makeStyles((theme: Theme) =>
       flexGrow: 1,
     },
     paper: {
-      padding: theme.spacing(1),
       textAlign: "center",
       color: theme.palette.text.secondary,
       minWidth: 30,

--- a/src/components/phonenumber/index.tsx
+++ b/src/components/phonenumber/index.tsx
@@ -17,9 +17,6 @@ import { WHITE } from "../../colorscheme";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    root: {
-      flexGrow: 1,
-    },
     paper: {
       textAlign: "center",
       color: theme.palette.text.secondary,
@@ -86,9 +83,9 @@ const PhoneNumberComponent: React.FC<PhoneNumberPropsType> = ({
   });
 
   return (
-    <div key={pk} className={classes.root}>
+    <div key={pk}>
       <Paper className={classes.paper}>
-        <form className={classes.root} noValidate autoComplete="off">
+        <form noValidate autoComplete="off">
           <TextField
             error={invalidPhoneNumber}
             required


### PR DESCRIPTION
Fixes #434 
Updates  css for the phonenumber component.
Vertically aligns buttons, adds margins and evenly spaces the buttons out inside the paper.
Removes CSS that either wasnt used or didnt do anything.