### PR TITLE
Make day select menu stay still

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 
 ### Fixed
 - Fix ARGUS logo clipping part of the name.
-- Fix a bug in Timeslot's time pickers where changing start-/end time via icon, leads to wrong values being registered, misleading error text being displayed, and "Save"-button being disabled 
+- Fix a bug in Timeslot's time pickers where changing start-/end time via icon, leads to wrong values being registered, misleading error text being displayed, and "Save"-button being disabled
 - Fix a bug in Timeslot's time pickers where typing invalid values for both start- and end time (both input fields display error text), disrupts further changes (incl. corrections) of those time values
-- Fix a bug in Timeslot's time pickers where error text is not always removed and "Save"-button is disabled, even after user has provided valid and non-conflicting values (time range where start time is before end time) 
+- Fix a bug in Timeslot's time pickers where error text is not always removed and "Save"-button is disabled, even after user has provided valid and non-conflicting values (time range where start time is before end time)
 - Fix bug where incidents count was messed up due to user switching between table pages too rapidly
 
 - Labeling of "Unacked" chips and buttons is now consistent.
 - Incidents page does not blank out anymore when selecting an old-style filter (filter created before 2023).
+
+- Fix a bug where the day selector menu for timeslots would jump around when selecting days.
 
 
 ### Changed

--- a/src/components/timeslot/index.tsx
+++ b/src/components/timeslot/index.tsx
@@ -304,6 +304,10 @@ export const DaySelector: React.FC<DaySelectorPropsType> = ({
           );
         }}
         disabled={disabled}
+        MenuProps={{
+          variant: "menu",
+          getContentAnchorEl: null,
+        }}
       >
         {TIME_RECURRENCE_DAY_IN_ORDER.map((day: TimeRecurrenceDay) => (
           <MenuItem key={day} value={day} selected>


### PR DESCRIPTION
Fixes #435.

Based on this discussion from the MUI repo: https://github.com/mui/material-ui/issues/19977