### PR TITLE
Fix enter button not saving/updating telephone number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 - Incidents page does not blank out anymore when selecting an old-style filter (filter created before 2023).
 
 - Fix a bug where the day selector menu for timeslots would jump around when selecting days.
+- Fix a bug where pressing enter while creating or updating a phone number refreshed the page instead of actually
+creating or updating the phone number.
 
 
 ### Changed

--- a/src/components/phonenumber/index.tsx
+++ b/src/components/phonenumber/index.tsx
@@ -89,7 +89,15 @@ const PhoneNumberComponent: React.FC<PhoneNumberPropsType> = ({
   return (
     <div key={pk}>
       <Paper className={classes.paper}>
-        <form className={classes.form} noValidate autoComplete="off">
+        <form
+          className={classes.form}
+          noValidate autoComplete="off"
+          onSubmit={(event) => {
+            event.preventDefault();
+            setUpdateLoading(true);
+            onSave(pk, phoneNumber);
+          }}
+        >
           <TextField
             error={invalidPhoneNumber}
             required
@@ -103,12 +111,9 @@ const PhoneNumberComponent: React.FC<PhoneNumberPropsType> = ({
             variant="contained"
             size="small"
             className={classes.saveButton}
-            onClick={() => {
-              setUpdateLoading(true);
-              onSave(pk, phoneNumber);
-            }}
             disabled={!hasChanged || invalidPhoneNumber}
             startIcon={updateLoading ? <Spinning shouldSpin /> : <SaveIcon />}
+            type="submit"
           >
             {exists ? "Save" : "Create"}
           </Button>


### PR DESCRIPTION
Previosuly the button worked by having an OnClick event. But at the same time the form still seemed to have a submit event
that triggered when you press enter inside the form, and the default behaviour is to refresh the page.
This fix puts the OnClick logicinside a OnSubmit handler instead, while disabling the default submit behaviour (stops the page from rereshing). This makes it so
pressing enter and clicking the save/create button behaves the same way- They should both behave the same as the old behaviour for clicking the button.

Fixes #433 