### PR TITLE
Use plural words when bulk operating multiple incidents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 creating or updating the phone number.
 
 
+
+
 ### Changed
 
 - Individual success alerts are replaced with a consolidated success message for bulk updates (bulk ack, bulk add/ticket etc.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 - Rename the label for the severity level selector from "Max level" to "Max severity level"
 
 
+## fix.bulk-dialogue-fix
+
+### Fixed
+- Fix help text refering to a singular incident when ACK-ing or closing multiple incidents with the bulk operation feature.
+
 
 
 ## [Unreleased]
@@ -40,8 +45,6 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 - Fix a bug where the day selector menu for timeslots would jump around when selecting days.
 - Fix a bug where pressing enter while creating or updating a phone number refreshed the page instead of actually
 creating or updating the phone number.
-
-
 
 
 ### Changed

--- a/src/components/incident/CreateAckSignOffAction.tsx
+++ b/src/components/incident/CreateAckSignOffAction.tsx
@@ -52,7 +52,7 @@ const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck, signOffActionPro
 
   const signOffActionPluralProps = {
     dialogContentText: "Write a message describing why the incidents were acknowledged",
-    question: "Are you sure you want to acknowledge these incident?",
+    question: "Are you sure you want to acknowledge these incidents?",
   }
 
   return (

--- a/src/components/incident/CreateAckSignOffAction.tsx
+++ b/src/components/incident/CreateAckSignOffAction.tsx
@@ -38,7 +38,7 @@ const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck, signOffActionPro
   return (
     <SignOffAction
       dialogTitle="Submit acknowledment"
-      dialogContentText="Write a message describing why this incident was acknowledged "
+      dialogContentText="Write a message describing why this incident was acknowledged"
       dialogSubmitText="Submit"
       dialogCancelText="Cancel"
       dialogButtonText="Create acknowledegment"

--- a/src/components/incident/CreateAckSignOffAction.tsx
+++ b/src/components/incident/CreateAckSignOffAction.tsx
@@ -15,9 +15,10 @@ import SignOffAction, { SignOffActionPropsType } from "./SignOffAction";
 type CreateAckPropsType = {
   onSubmitAck: (ack: AcknowledgementBody) => void;
   signOffActionProps?: Partial<SignOffActionPropsType>;
+  isBulk: boolean;
 };
 
-const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck, signOffActionProps = {} }: CreateAckPropsType) => {
+const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck, signOffActionProps = {}, isBulk }: CreateAckPropsType) => {
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
   const handleSubmit = (msg: string) => {
@@ -35,19 +36,29 @@ const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck, signOffActionPro
     setSelectedDate(date);
   };
 
+  const signOffActionpDefaultProps = {
+    dialogTitle: "Submit acknowledment",
+    dialogContentText: "Write a message describing why this incident was acknowledged",
+    dialogSubmitText: "Submit",
+    dialogCancelText: "Cancel",
+    dialogButtonText: "Create acknowledegment",
+    dialogInputLabel: "Acknowledgment message",
+    isDialogInputRequired:false,
+    dialogInputType: "text",
+    title: "Submit acknowledment",
+    question: "Are you sure you want to acknowledge this incident?",
+    onSubmit: handleSubmit,
+  }
+
+  const signOffActionPluralProps = {
+    dialogContentText: "Write a message describing why the incidents were acknowledged",
+    question: "Are you sure you want to acknowledge these incident?",
+  }
+
   return (
     <SignOffAction
-      dialogTitle="Submit acknowledment"
-      dialogContentText="Write a message describing why this incident was acknowledged"
-      dialogSubmitText="Submit"
-      dialogCancelText="Cancel"
-      dialogButtonText="Create acknowledegment"
-      dialogInputLabel="Acknowledgment message"
-      isDialogInputRequired={false}
-      dialogInputType="text"
-      title="Submit acknowledment"
-      question="Are you sure you want to acknowledge this incident?"
-      onSubmit={handleSubmit}
+      {...signOffActionpDefaultProps}
+      {...(isBulk && signOffActionPluralProps)}
       {...signOffActionProps}
     >
       <MuiPickersUtilsProvider utils={DateFnsUtils}>

--- a/src/components/incident/CreateAckSignOffAction.tsx
+++ b/src/components/incident/CreateAckSignOffAction.tsx
@@ -36,7 +36,7 @@ const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck, signOffActionPro
     setSelectedDate(date);
   };
 
-  const signOffActionpDefaultProps = {
+  const signOffActionDefaultProps = {
     dialogTitle: "Submit acknowledment",
     dialogContentText: "Write a message describing why this incident was acknowledged",
     dialogSubmitText: "Submit",
@@ -57,7 +57,7 @@ const CreateAck: React.FC<CreateAckPropsType> = ({ onSubmitAck, signOffActionPro
 
   return (
     <SignOffAction
-      {...signOffActionpDefaultProps}
+      {...signOffActionDefaultProps}
       {...(isBulk && signOffActionPluralProps)}
       {...signOffActionProps}
     >

--- a/src/components/incident/IncidentDetails.tsx
+++ b/src/components/incident/IncidentDetails.tsx
@@ -450,6 +450,7 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
                         open={incident.open}
                         onManualClose={handleManualClose}
                         onManualOpen={handleManualOpen}
+                        isBulk={false}
                       />
                     </CenterContainer>
                   </ListItem>
@@ -473,6 +474,7 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
             <CenterContainer>
               <CreateAck
                 key={(acks || []).length}
+                isBulk={false}
                 onSubmitAck={(ack: AcknowledgementBody) => {
                   api
                     .postAck(incident.pk, ack)
@@ -622,11 +624,13 @@ const IncidentDetails: React.FC<IncidentDetailsPropsType> = ({
                         open={incident.open}
                         onManualClose={handleManualClose}
                         onManualOpen={handleManualOpen}
+                        isBulk={false}
                       />
                     </Grid>
                     <Grid item className="ack-button-container">
                       <CreateAck
                         key={(acks || []).length}
+                        isBulk={false}
                         onSubmitAck={(ack: AcknowledgementBody) => {
                           api
                             .postAck(incident.pk, ack)

--- a/src/components/incident/ManualCloseSignOffAction.tsx
+++ b/src/components/incident/ManualCloseSignOffAction.tsx
@@ -54,6 +54,17 @@ const ManualClose: React.FC<ManualClosePropsType> = ({
     question: "Are you sure you want to close these incidents?",
   }
 
+  const reopenButtonDefaultProps = {
+    title: "Reopen incident",
+    question: "Are you sure you want to reopen this incident?",
+    onConfirm: onManualOpen,
+    ButtonComponent: ButtonComponent,
+  }
+
+  const reopenButtonPluralProps = {
+    title: "Reopen incidents",
+    question: "Are you sure you want to reopen these incidents?",
+  }
 
 
   if (open) {
@@ -67,14 +78,12 @@ const ManualClose: React.FC<ManualClosePropsType> = ({
   } else {
     return (
       <ConfirmationButton
-        title={"Reopen incident"}
-        question={"Are you sure you want to reopen this incident?"}
-        onConfirm={onManualOpen}
-        ButtonComponent={ButtonComponent}
-        buttonProps={{
-            variant: "contained"
-        }}
         className={classes.dangerousButton}
+        buttonProps={{
+            variant: "contained",
+        }}
+        {...reopenButtonDefaultProps}
+        {... (isBulk && reopenButtonPluralProps)}
         {...reopenButtonProps}
       >
         {reopenButtonText}

--- a/src/components/incident/ManualCloseSignOffAction.tsx
+++ b/src/components/incident/ManualCloseSignOffAction.tsx
@@ -34,7 +34,7 @@ const ManualClose: React.FC<ManualClosePropsType> = ({
 }: ManualClosePropsType) => {
   const classes = useStyles();
 
-  const signOffActionpDefaultProps = {
+  const signOffActionDefaultProps = {
     dialogTitle: "Manually close incident",
     dialogContentText: "Write a message describing why the incident was manually closed",
     dialogSubmitText:"Close now",
@@ -51,13 +51,15 @@ const ManualClose: React.FC<ManualClosePropsType> = ({
   const signOffActionPluralProps = {
     dialogTitle: "Manually close incidents",
     dialogContentText: "Write a message describing why the incidents were manually closed",
-    question: "Are you sure you want to close these incident?",
+    question: "Are you sure you want to close these incidents?",
   }
+
+
 
   if (open) {
     return (
       <SignOffAction
-        {...signOffActionpDefaultProps}
+        {...signOffActionDefaultProps}
         {...(isBulk && signOffActionPluralProps)}
         {...signOffActionProps}
       />

--- a/src/components/incident/ManualCloseSignOffAction.tsx
+++ b/src/components/incident/ManualCloseSignOffAction.tsx
@@ -83,7 +83,7 @@ const ManualClose: React.FC<ManualClosePropsType> = ({
             variant: "contained",
         }}
         {...reopenButtonDefaultProps}
-        {... (isBulk && reopenButtonPluralProps)}
+        {...(isBulk && reopenButtonPluralProps)}
         {...reopenButtonProps}
       >
         {reopenButtonText}

--- a/src/components/incident/ManualCloseSignOffAction.tsx
+++ b/src/components/incident/ManualCloseSignOffAction.tsx
@@ -18,6 +18,7 @@ type ManualClosePropsType = {
   signOffActionProps?: Partial<SignOffActionPropsType>;
   reopenButtonProps?: Partial<ButtonProps>;
   ButtonComponent?: React.ElementType<{ onClick: ButtonProps["onClick"] }>;
+  isBulk: boolean;
 };
 
 const ManualClose: React.FC<ManualClosePropsType> = ({
@@ -29,23 +30,35 @@ const ManualClose: React.FC<ManualClosePropsType> = ({
   signOffActionProps = {},
   reopenButtonProps = {},
   ButtonComponent = Button,
+  isBulk,
 }: ManualClosePropsType) => {
   const classes = useStyles();
+
+  const signOffActionpDefaultProps = {
+    dialogTitle: "Manually close incident",
+    dialogContentText: "Write a message describing why the incident was manually closed",
+    dialogSubmitText:"Close now",
+    dialogCancelText:"Cancel",
+    dialogButtonText: closeButtonText,
+    dialogInputLabel: "Closing message",
+    isDialogInputRequired: false,
+    dialogInputType: "text",
+    title: "Manually close incident",
+    question: "Are you sure you want to close this incident?",
+    onSubmit: onManualClose,
+  }
+
+  const signOffActionPluralProps = {
+    dialogTitle: "Manually close incidents",
+    dialogContentText: "Write a message describing why the incidents were manually closed",
+    question: "Are you sure you want to close these incident?",
+  }
 
   if (open) {
     return (
       <SignOffAction
-        dialogTitle="Manually close incident"
-        dialogContentText="Write a message describing why the incident was manually closed"
-        dialogSubmitText="Close now"
-        dialogCancelText="Cancel"
-        dialogButtonText={closeButtonText}
-        dialogInputLabel="Closing message"
-        isDialogInputRequired={false}
-        dialogInputType="text"
-        title="Manually close incident"
-        question="Are you sure you want to close this incident?"
-        onSubmit={onManualClose}
+        {...signOffActionpDefaultProps}
+        {...(isBulk && signOffActionPluralProps)}
         {...signOffActionProps}
       />
     );

--- a/src/components/incidenttable/IncidentTableToolbar.tsx
+++ b/src/components/incidenttable/IncidentTableToolbar.tsx
@@ -169,11 +169,11 @@ export const TableToolbar: React.FC<TableToolbarPropsType> = ({
                 });
               }
             }}
+            isBulk={ selectedIncidents.size > 1 }
             signOffActionProps={{
               dialogButtonText: "Ack",
               ButtonComponent: OutlinedButton,
-              buttonProps: { className: "sign-off-button" },
-              ...(selectedIncidents.size > 1 && {dialogContentText: "Write a message describing why the incidents were acknowledged"})
+              buttonProps: { className: "sign-off-button" }
             }}
           />
 
@@ -232,10 +232,10 @@ export const TableToolbar: React.FC<TableToolbarPropsType> = ({
               }}
               reopenButtonText="Re-open selected"
               closeButtonText="Close selected"
+              isBulk={ selectedIncidents.size > 1 }
               signOffActionProps={{
                 ButtonComponent: OutlinedButton,
-                buttonProps: { className: "sign-off-button"},
-                ...(selectedIncidents.size > 1 && {dialogContentText: "Write a message describing why the incidents were manually closed"})
+                buttonProps: { className: "sign-off-button"}
               }}
               reopenButtonProps={{ className: "sign-off-button", variant: "outlined"}}
               ButtonComponent={OutlinedButton}

--- a/src/components/incidenttable/IncidentTableToolbar.tsx
+++ b/src/components/incidenttable/IncidentTableToolbar.tsx
@@ -92,7 +92,7 @@ export const TableToolbar: React.FC<TableToolbarPropsType> = ({
   return (
     <Toolbar
       variant="dense"
-      className={`${selectedIncidents.size === 0 
+      className={`${selectedIncidents.size === 0
         ? classes.root : `${classNames(classes.root, classes.selected)} incident-table-toolbar-selected`}
         `}
     >
@@ -173,6 +173,7 @@ export const TableToolbar: React.FC<TableToolbarPropsType> = ({
               dialogButtonText: "Ack",
               ButtonComponent: OutlinedButton,
               buttonProps: { className: "sign-off-button" },
+              ...(selectedIncidents.size > 1 && {dialogContentText: "Write a message describing why the incidents were acknowledged"})
             }}
           />
 
@@ -234,6 +235,7 @@ export const TableToolbar: React.FC<TableToolbarPropsType> = ({
               signOffActionProps={{
                 ButtonComponent: OutlinedButton,
                 buttonProps: { className: "sign-off-button"},
+                ...(selectedIncidents.size > 1 && {dialogContentText: "Write a message describing why the incidents were manually closed"})
               }}
               reopenButtonProps={{ className: "sign-off-button", variant: "outlined"}}
               ButtonComponent={OutlinedButton}

--- a/src/components/incidenttable/IncidentTableToolbar.tsx
+++ b/src/components/incidenttable/IncidentTableToolbar.tsx
@@ -173,7 +173,7 @@ export const TableToolbar: React.FC<TableToolbarPropsType> = ({
             signOffActionProps={{
               dialogButtonText: "Ack",
               ButtonComponent: OutlinedButton,
-              buttonProps: { className: "sign-off-button" }
+              buttonProps: { className: "sign-off-button" },
             }}
           />
 
@@ -235,7 +235,7 @@ export const TableToolbar: React.FC<TableToolbarPropsType> = ({
               isBulk={ selectedIncidents.size > 1 }
               signOffActionProps={{
                 ButtonComponent: OutlinedButton,
-                buttonProps: { className: "sign-off-button"}
+                buttonProps: { className: "sign-off-button" },
               }}
               reopenButtonProps={{ className: "sign-off-button", variant: "outlined"}}
               ButtonComponent={OutlinedButton}


### PR DESCRIPTION
Fixes parts of #423 
also removes some trailing whitespace

Uses spread operator to only override the text if multiple incidents are selected. Is this a clean way to do it?