### PR TITLE
Build and publish production-oriented builder Docker image as GitHub package

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,43 @@
+# Much inspired from https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+name: Create and publish Argus front-end Docker image
+
+on:
+  release:
+    types: [published, edited]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push backend Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+# This image installs all dependencies and "pre-builds" an Argus frontend
+# site, intended as a stepstone builder image for a full production site.
+# It should run with the git repo root as the build context
+FROM node:16-bullseye
+WORKDIR /app
+
+COPY . /app
+
+RUN npm ci
+RUN npx browserslist@latest --update-db
+RUN npm run build
+
+ONBUILD RUN npm run build
+
+# When used as an intermediate builder image, the complete set of statically
+# built files to serve from the web server root can be copied from /app/build

--- a/docker/README.md
+++ b/docker/README.md
@@ -76,3 +76,13 @@ CMD ["nginx", "-g", "daemon off;"]
 The first stage builds a set of static files based on your build arguments. The
 second stage copies the produced file tree and serves it using an nginx web
 server.
+
+## Limitations
+
+This is not a complete Argus environment.  This image only provides the
+single-page user interface application to operate against an [Argus API
+server](https://github.com/Uninett/Argus). The API server also has dependencies
+to other services.
+
+For a full production environment example, take a look at
+https://github.com/Uninett/argus-docker

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,78 @@
+# Docker production image of Argus frontend
+
+Whereas the top-level Dockerfile is development-oriented, this directory
+contains definitions to build a production-oriented Docker image of the Argus
+front-end / user interface application.
+
+However, as the front-end is a React-based application built from TypeScript
+sources, the necessary configuration to talk to an Argus API back-end server is
+staticailly compiled into the resulting web site.
+
+This image can therefore only be used to serve as a intermediate build image,
+to produce the actual statically compiled application with your site's settings
+embedded.
+
+To build this image, the build context needs to be that of the git repository
+root. Something like this would work (when the current working directory is
+here):
+
+```shell
+docker build -t argus-frontend -f Dockerfile ..
+```
+
+Or, from the top level directory:
+
+```shell
+docker build -t argus-frontend -f docker/Dockerfile .
+```
+
+## Using this intermediate image for building a production site
+
+To build a complete Argus front-end application for your site, you need to
+write a two-stage `Dockerfile`.
+
+The first stage will be based on this image, while taking the necessary build
+configuration as Docker build arguments, then building the React application
+using `npm`. The resulting files should be served in the document root of any
+web server. The can be copied from the path `/app/build` in the first stage
+build container.
+
+The image defined here will normally be published as
+`ghcr.io/uninett/argus-frontend:<version>`. If you want to build a production
+site from Argus frontend version *1.6.1*, you would write something like this:
+
+```Dockerfile
+FROM ghcr.io/uninett/argus-frontend:1.6.1 AS build
+
+# These arguments are needed in the environment to properly configure and build
+# Argus-frontend for this site:
+ARG REACT_APP_BACKEND_URL=http://argus.example.org
+ARG REACT_APP_ENABLE_WEBSOCKETS_SUPPORT=true
+ARG REACT_APP_BACKEND_WS_URL=wss://argus.example.org/ws
+ARG REACT_APP_USE_SECURE_COOKIE=true
+ARG REACT_APP_DEBUG=true
+ARG REACT_APP_DEFAULT_AUTO_REFRESH_INTERVAL=30
+ARG REACT_APP_REALTIME_SERVICE_MAX_RETRIES=5
+ARG REACT_APP_COOKIE_DOMAIN=argus.example.org
+
+RUN npm run build
+
+##########################################################
+# Stage 2:
+# production environment consisting only of nginx and the statically compiled
+# Argus Frontend application files
+# FROM: https://mherman.org/blog/dockerizing-a-react-app/
+FROM nginx:stable-alpine
+
+COPY --from=build /app/build /usr/share/nginx/html
+
+RUN apk add --update tini tree
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+ENTRYPOINT ["/sbin/tini", "-v", "--"]
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+The first stage builds a set of static files based on your build arguments. The
+second stage copies the produced file tree and serves it using an nginx web
+server.


### PR DESCRIPTION
To implement Uninett/argus-docker#1 in a more fluent way, production-oriented Docker images of the back-end and front-end components should be built and published as packages attached to each of the source repositories.

This adds a Dockerfile to produce a production oriented image of the front-end UI application, and sets up a GitHub Actions workflow to build and publish said image as a *package* on every release made from this repo.

Because of how the site configuration is compiled in the statically generated application files, this image is just a stage 1 build image, so documentation on how to use it is added to a `README.md` file.