### PR TITLE
Add global state logic and API calls for destinations

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -36,8 +36,8 @@ import {
   CursorPaginationResponse,
   ApiListener,
   Resolver,
-  ErrorCreator, 
-  MetadataConfig,
+  ErrorCreator,
+  MetadataConfig, Media, Destination, MediaSchema, DestinationPK, DestinationRequest, NewDestination,
 } from "./types.d";
 
 import auth from "../auth";
@@ -316,6 +316,57 @@ class ApiClient {
       .catch((error) => {
         return Promise.reject(new Error(`Failed to delete notification profile ${profile}: ${getErrorCause(error)}`));
       });
+  }
+
+  // Destinations
+  public getAllMedia(): Promise<Media[]> {
+    return this.resolveOrReject(
+        this.authGet<Media[], never>(`/api/v2/notificationprofiles/media/`),
+        defaultResolver,
+        (error) => new Error(`Failed to get configured media: ${getErrorCause(error)}`),
+    );
+  }
+
+  public getAllDestinations(): Promise<Destination[]> {
+    return this.resolveOrReject(
+        this.authGet<Destination[], never>(`/api/v2/notificationprofiles/destinations/`),
+        defaultResolver,
+        (error) => new Error(`Failed to get destinations: ${getErrorCause(error)}`),
+    );
+  }
+
+  public getMediaSchemaBySlug(slug: string): Promise<MediaSchema> {
+    return this.resolveOrReject(
+        this.authGet<MediaSchema, string>(`/api/v2/notificationprofiles/media/${slug}/json_schema/`),
+        defaultResolver,
+        (error) => new Error(`Failed to get media schema of type ${slug}: ${getErrorCause(error)}`),
+    );
+  }
+
+  // Create new destination
+  public postDestination(destination: NewDestination): Promise<Destination> {
+    return this.resolveOrReject(
+        this.authPost<Destination, NewDestination>(`/api/v2/notificationprofiles/destinations/`, destination),
+        defaultResolver,
+        (error) => new Error(`Failed to create destination ${destination.label}: ${getErrorCause(error)}`),
+    );
+  }
+
+  public deleteDestination(destinationPk: DestinationPK): Promise<void> {
+    return this.resolveOrReject(
+        this.authDelete<never, DestinationPK>(`/api/v2/notificationprofiles/destinations/${destinationPk}`),
+        defaultResolver,
+        (error) => new Error(`Failed to delete destination ${destinationPk}: ${getErrorCause(error)}`),
+    );
+  }
+
+  // Update existing destination destination
+  public putDestination(destination: DestinationRequest): Promise<Destination> {
+    return this.resolveOrReject(
+        this.authPatch<Destination, DestinationRequest>(`/api/v2/notificationprofiles/destinations/${destination.pk}/`, destination),
+        defaultResolver,
+        (error) => new Error(`Failed to update destination ${destination.pk}: ${getErrorCause(error)}`),
+    );
   }
 
   public postIncidentReopenEvent(pk: number): Promise<Event> {

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -112,6 +112,62 @@ export interface NotificationProfile {
 }
 
 /*
+ * Destinations
+ */
+
+export type DestinationPK = number;
+
+export type Media = {
+  slug: string;
+  name: string;
+}
+
+export type MediaProperty = {
+  title: string;
+  type: string; // value type
+  description?: string;
+  format?: string;
+}
+
+export type MediaSchema = {
+  json_schema: {
+    $id: string;
+    description: string;
+    properties: {
+      [property_name: string]: MediaProperty;
+    };
+    required: KnownProperties[] | undefined;
+    title: string;
+  }
+}
+
+export type DestinationRequest = {
+  pk: DestinationPK;
+  label?: string | undefined; // title given by user
+  media: string; // media slug
+  settings?: DestinationSettings;
+}
+
+export type DestinationSettings = {
+  [property_name: string]: string | boolean;
+};
+
+export type Destination = {
+  pk: DestinationPK;
+  label: string | undefined; // title given by user
+  media: Media;
+  settings: DestinationSettings
+  suggested_label: string;
+}
+
+export type NewDestination = {
+  label: string | undefined; // title given by user
+  media: string; // media slug
+  settings: DestinationSettings;
+}
+
+
+/*
  * Incidents
  */
 

--- a/src/state/contexts.tsx
+++ b/src/state/contexts.tsx
@@ -6,6 +6,12 @@ import { initialUserState, userReducer, UserActions, UserStateType } from "../st
 import { initialApiState, apiStateReducer, ApiStateActions, ApiState } from "../state/reducers/apistate";
 import { initialTimeframeState, TimeframeActions, timeframeReducer, TimeframeStateType } from "./reducers/timeframe";
 import {initialTicketState, TicketActions, ticketReducer, TicketStateType} from "./reducers/ticketurl";
+import {
+  DestinationsActions,
+  destinationsReducer,
+  DestinationsStateType,
+  initialDestinationsState
+} from "./reducers/destinations";
 
 export type InitialStateType = {
   // List of all filters that the currently
@@ -15,6 +21,7 @@ export type InitialStateType = {
   apiState: ApiState;
   timeframe: TimeframeStateType;
   ticketState: TicketStateType;
+  destinationsState: DestinationsStateType;
 };
 
 const initialState: InitialStateType = {
@@ -23,10 +30,10 @@ const initialState: InitialStateType = {
   apiState: initialApiState,
   timeframe: initialTimeframeState,
   ticketState: initialTicketState,
+  destinationsState: initialDestinationsState,
 };
 
-export type ActionsType = FilterActions | UserActions | ApiStateActions | TimeframeActions | TicketActions /*  | AnotherAction ... */;
-
+export type ActionsType = FilterActions | UserActions | ApiStateActions | TimeframeActions | TicketActions | DestinationsActions /*  | AnotherAction ... */;
 const AppContext = createContext<{
   state: InitialStateType;
   dispatch: React.Dispatch<ActionsType>;
@@ -35,12 +42,13 @@ const AppContext = createContext<{
   dispatch: () => null,
 });
 
-const mainReducer = ({ filters, user, apiState, timeframe, ticketState }: InitialStateType, action: ActionsType) => ({
+const mainReducer = ({ filters, user, apiState, timeframe, ticketState, destinationsState }: InitialStateType, action: ActionsType) => ({
   filters: filterReducer(filters, action as FilterActions),
   user: userReducer(user, action as UserActions),
   apiState: apiStateReducer(apiState, action as ApiStateActions),
   timeframe: timeframeReducer(timeframe, action as TimeframeActions),
   ticketState: ticketReducer(ticketState, action as TicketActions),
+  destinationsState: destinationsReducer(destinationsState, action as DestinationsActions),
 });
 
 const AppProvider: React.FC = ({ children }: { children?: React.ReactNode }) => {

--- a/src/state/hooks.tsx
+++ b/src/state/hooks.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useContext} from "react";
 
-import type {AutoUpdateMethod, User, Token} from "../api/types.d";
+import type {AutoUpdateMethod, User, Token, Media, Destination} from "../api/types.d";
 
 import {
   ApiState,
@@ -23,6 +23,13 @@ import {
   resetTicketState,
   TicketStateType
 } from "./reducers/ticketurl";
+import {
+  createDestination, deleteDestination,
+  DestinationsStateType,
+  fetchConfiguredMedia,
+  loadDestinations,
+  modifyDestination
+} from "./reducers/destinations";
 
 export type UseApiStateActionType = {
   setAutoUpdateMethod: (method: AutoUpdateMethod) => void;
@@ -138,6 +145,42 @@ export const useTicket = (): [TicketStateType, UseTicketActionType] => {
       invalidUrl: invalidUrlCallback,
       manuallyEditTicket: manuallyEditTicketCallback,
       resetTicketState: resetTicketStateCallback,
+    },
+  ];
+};
+
+/*
+ * Destination
+ */
+export type UseDestinationsActionType = {
+  fetchConfiguredMedia: (configuredMedia: Media[]) => void;
+  loadDestinations: (destinations: Destination[]) => void;
+  modifyDestination: (destination: Destination) => void;
+  createDestination: (destination: Destination) => void;
+  deleteDestination: (destination: Destination) => void;
+};
+
+export const useDestinations = (): [DestinationsStateType, UseDestinationsActionType] => {
+  const {
+    state: { destinationsState },
+    dispatch,
+  } = useContext(AppContext);
+
+  const fetchConfiguredMediaCallback = useCallback((configuredMedia: Media[]) => dispatch(fetchConfiguredMedia(configuredMedia)), [dispatch]);
+  const loadDestinationsCallback = useCallback((destinations: Destination[]) => dispatch(loadDestinations(destinations)), [dispatch]);
+  const modifyDestinationCallback = useCallback((destination: Destination) => dispatch(modifyDestination(destination)), [dispatch]);
+  const createDestinationCallback = useCallback((destination: Destination) => dispatch(createDestination(destination)), [dispatch]);
+  const deleteDestinationCallback = useCallback((destination: Destination) => dispatch(deleteDestination(destination)), [dispatch]);
+
+
+  return [
+    destinationsState,
+    {
+      fetchConfiguredMedia: fetchConfiguredMediaCallback,
+      loadDestinations: loadDestinationsCallback,
+      modifyDestination: modifyDestinationCallback,
+      createDestination: createDestinationCallback,
+      deleteDestination: deleteDestinationCallback,
     },
   ];
 };

--- a/src/state/reducers/destinations.ts
+++ b/src/state/reducers/destinations.ts
@@ -1,0 +1,115 @@
+import type {Media} from "../../api/types.d";
+import { ActionMap, makeAction } from "./common";
+import {Destination} from "../../api/types.d";
+
+
+export type DestinationsStateType = {
+    configuredMedia: Media[];
+    knownMediaTypes: Media["slug"][]; // derived from configured media
+
+    destinations: Map<Media["slug"], Destination[]> // all users destinations mapped after media type
+};
+
+export enum DestinationsType {
+    FetchConfiguredMedia = "FETCH_MEDIA",
+
+    LoadDestinations = "GET_DESTINATIONS",
+    ModifyDestination = "PATCH_DESTINATION",
+    CreateDestination = "POST_DESTINATION",
+    DeleteDestination = "DELETE_DESTINATION",
+}
+
+type DestinationsPayload = {
+    [DestinationsType.FetchConfiguredMedia]: Media[];
+
+    [DestinationsType.LoadDestinations]: Destination[];
+    [DestinationsType.ModifyDestination]: Destination;
+    [DestinationsType.CreateDestination]: Destination;
+    [DestinationsType.DeleteDestination]: Destination;
+};
+
+export const initialDestinationsState: DestinationsStateType = {
+    configuredMedia: [],
+    knownMediaTypes: [],
+
+    destinations: new Map<Media["slug"], Destination[]>(),
+};
+
+export type DestinationsActions = ActionMap<DestinationsPayload>[keyof ActionMap<DestinationsPayload>];
+export const destinationsReducer = (state: DestinationsStateType, action: DestinationsActions) => {
+
+    // Helpers
+    const mapMediaToMediaTypes = (configuredMedia: Media[]): Media["slug"][] => {
+        return configuredMedia.map((media) => {
+            return media.slug
+        })
+    };
+
+    const mapDestinationsAfterMediaType = (destinations: Destination[], knownMediaTypes: Media["slug"][]): Map<Media["slug"], Destination[]> => {
+        const destinationByKnownTypes = new Map<string, Destination[]>()
+        knownMediaTypes.forEach((m) => {
+            destinationByKnownTypes.set(m, destinations.filter((dest) => dest.media.slug === m));
+        })
+        return destinationByKnownTypes;
+    }
+
+    const addDestination = (existingDestinations: Map<Media["slug"], Destination[]>, newDestination: Destination): Map<Media["slug"], Destination[]> => {
+        const destinationByKnownTypes = new Map<string, Destination[]>(existingDestinations);
+        if (existingDestinations.entries() !== undefined && existingDestinations.get(newDestination.media.slug) !== undefined) {
+            // @ts-ignore
+            destinationByKnownTypes.set(newDestination.media.slug, [...existingDestinations?.get(newDestination.media.slug), newDestination])
+        }
+        return destinationByKnownTypes;
+    }
+
+    const updateDestination = (existingDestinations: Map<Media["slug"], Destination[]>, updatedDestination: Destination): Map<Media["slug"], Destination[]> => {
+        const destinationByKnownTypes = new Map<string, Destination[]>(existingDestinations);
+        if (existingDestinations.entries() !== undefined && existingDestinations.get(updatedDestination.media.slug) !== undefined) {
+            // @ts-ignore
+            destinationByKnownTypes.set(updatedDestination.media.slug, [...existingDestinations?.get(updatedDestination.media.slug)])
+        }
+        return destinationByKnownTypes;
+    }
+
+    const deleteDestination = (existingDestinations: Map<Media["slug"], Destination[]>, deletedDestinationEntry: Destination): Map<Media["slug"], Destination[]> => {
+        const destinationByKnownTypes = new Map<string, Destination[]>(existingDestinations);
+        if (existingDestinations.entries() !== undefined && existingDestinations.get(deletedDestinationEntry.media.slug) !== undefined) {
+            // @ts-ignore
+            destinationByKnownTypes.set(deletedDestinationEntry.media.slug, [...existingDestinations?.get(deletedDestinationEntry.media.slug).filter(e => e.pk !== deletedDestinationEntry.pk)])
+        }
+        return destinationByKnownTypes;
+    }
+
+
+    switch (action.type) {
+        case DestinationsType.FetchConfiguredMedia:
+            return {...state,
+                configuredMedia: action.payload,
+                knownMediaTypes: mapMediaToMediaTypes(action.payload),
+            };
+        case DestinationsType.LoadDestinations:
+            return {...state,
+                destinations: mapDestinationsAfterMediaType(action.payload, state.knownMediaTypes),
+            };
+        case DestinationsType.CreateDestination:
+            return {...state,
+                destinations: addDestination(state.destinations, action.payload),
+            };
+        case DestinationsType.ModifyDestination:
+            return {...state,
+                destinations: updateDestination(state.destinations, action.payload),
+            };
+        case DestinationsType.DeleteDestination:
+            return {...state,
+                destinations: deleteDestination(state.destinations, action.payload),
+            };
+        default:
+            return {...state};
+    }
+};
+
+export const fetchConfiguredMedia = makeAction<DestinationsType.FetchConfiguredMedia, Media[]>(DestinationsType.FetchConfiguredMedia);
+export const loadDestinations = makeAction<DestinationsType.LoadDestinations, Destination[]>(DestinationsType.LoadDestinations);
+export const modifyDestination = makeAction<DestinationsType.ModifyDestination, Destination>(DestinationsType.ModifyDestination);
+export const createDestination = makeAction<DestinationsType.CreateDestination, Destination>(DestinationsType.CreateDestination);
+export const deleteDestination = makeAction<DestinationsType.DeleteDestination, Destination>(DestinationsType.DeleteDestination);


### PR DESCRIPTION
Global state for destinations is needed since destinations data will be used in both destinations settings components, and notification profiles components. 

This PR offers no functional changes, just a preparation for adding destinations to Argus