### PR TITLE
Add destinations to notification profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 
 
 
+### Changed
+
+
+- Switched to API v.2 calls for notification profiles
+- The structure of notification profiles: removed the _Media_-selector, replaced the _Phone number_-selector with the _Destinations_-selector. User can now select multiple destinations per notification profile.
+
+
+
+
+
+
 ## [v1.7.0] - 2022-12-16
 
 ### Added

--- a/NOTES.md
+++ b/NOTES.md
@@ -12,6 +12,16 @@ This file documents changes to Argus-frontend that are important for the users t
 
 
 
+
+### Changed
+
+
+- The structure of notification profiles: removed the _Media_-selector, replaced the _Phone number_-selector with the _Destinations_-selector. User can now select multiple destinations per notification profile.
+
+
+
+
+
 ## [v1.7.0] - 2022-12-16
 
 ### Added

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -16,7 +16,6 @@ import {
   PhoneNumberRequest,
   PhoneNumberSuccessResponse,
   NotificationProfilePK,
-  NotificationProfile,
   Incident,
   Event,
   EventType,

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -11,7 +11,6 @@ import {
   Filter,
   FilterPK,
   FilterString,
-  MediaAlternative,
   PhoneNumberPK,
   PhoneNumber,
   PhoneNumberRequest,
@@ -241,17 +240,17 @@ class ApiClient {
   }
 
   // NotificationProfile
-  public getNotificationProfile(timeslot: TimeslotPK): Promise<NotificationProfile> {
+  public getNotificationProfile(pk: NotificationProfilePK): Promise<NotificationProfileSuccessResponse> {
     return this.resolveOrReject(
-      this.authGet<NotificationProfile, GetNotificationProfileRequest>(`/api/v1/notificationprofile/${timeslot}/`),
+      this.authGet<NotificationProfileSuccessResponse, GetNotificationProfileRequest>(`/api/v2/notificationprofile/${pk}/`),
       defaultResolver,
       (error) => new Error(`Failed to get notification profile: ${getErrorCause(error)}`),
     );
   }
 
-  public getAllNotificationProfiles(): Promise<NotificationProfile[]> {
+  public getAllNotificationProfiles(): Promise<NotificationProfileSuccessResponse[]> {
     return this.resolveOrReject(
-      this.authGet<NotificationProfile[], GetNotificationProfileRequest>(`/api/v1/notificationprofiles/`),
+      this.authGet<NotificationProfileSuccessResponse[], GetNotificationProfileRequest>(`/api/v2/notificationprofiles/`),
       defaultResolver,
       (error) => new Error(`Failed to get notification profiles: ${getErrorCause(error)}`),
     );
@@ -261,21 +260,19 @@ class ApiClient {
     profilePK: NotificationProfilePK,
     timeslot: TimeslotPK,
     filters: FilterPK[],
-    media: MediaAlternative[],
     active: boolean,
     // eslint-disable-next-line @typescript-eslint/camelcase
-    phone_number?: PhoneNumberPK | null,
-  ): Promise<NotificationProfile> {
+    destinations?: DestinationPK[] | null,
+  ): Promise<NotificationProfileSuccessResponse> {
     return this.resolveOrReject(
       this.authPut<NotificationProfileSuccessResponse, NotificationProfileRequest>(
-        `/api/v1/notificationprofiles/${profilePK}/`,
+        `/api/v2/notificationprofiles/${profilePK}/`,
         {
           timeslot: timeslot,
           filters,
-          media,
           active,
           // eslint-disable-next-line @typescript-eslint/camelcase
-          phone_number: phone_number || null,
+          destinations: destinations || null,
         },
       ),
       defaultResolver,
@@ -286,35 +283,33 @@ class ApiClient {
   public postNotificationProfile(
     timeslot: TimeslotPK,
     filters: FilterPK[],
-    media: MediaAlternative[],
     active: boolean,
     // eslint-disable-next-line
-    phone_number?: PhoneNumberPK | null,
-  ): Promise<NotificationProfile> {
+    destinations?: DestinationPK[] | null,
+  ): Promise<NotificationProfileSuccessResponse> {
     return this.resolveOrReject(
-      this.authPost<NotificationProfileSuccessResponse, NotificationProfileRequest>(`/api/v1/notificationprofiles/`, {
+      this.authPost<NotificationProfileSuccessResponse, NotificationProfileRequest>(`/api/v2/notificationprofiles/`, {
         // eslint-disable-next-line
         timeslot: timeslot,
         filters,
-        media,
         active,
         // eslint-disable-next-line
-        phone_number: phone_number || null,
+        destinations: destinations || null,
       }),
       defaultResolver,
-      (error) => new Error(`Failed to create notification profile ${timeslot}: ${getErrorCause(error)}`),
+      (error) => new Error(`Failed to create notification profile: ${getErrorCause(error)}`),
     );
   }
 
-  public deleteNotificationProfile(profile: NotificationProfilePK): Promise<boolean> {
+  public deleteNotificationProfile(profilePK: NotificationProfilePK): Promise<boolean> {
     return this.authDelete<NotificationProfileSuccessResponse, DeleteNotificationProfileRequest>(
-      `/api/v1/notificationprofiles/${profile}/`,
+      `/api/v2/notificationprofiles/${profilePK}/`,
     )
       .then(() => {
         return Promise.resolve(true);
       })
       .catch((error) => {
-        return Promise.reject(new Error(`Failed to delete notification profile ${profile}: ${getErrorCause(error)}`));
+        return Promise.reject(new Error(`Failed to delete notification profile ${profilePK}: ${getErrorCause(error)}`));
       });
   }
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -35,7 +35,13 @@ import {
   ApiListener,
   Resolver,
   ErrorCreator,
-  MetadataConfig, Media, Destination, MediaSchema, DestinationPK, DestinationRequest, NewDestination,
+  MetadataConfig,
+  Media,
+  Destination,
+  MediaSchema,
+  DestinationPK,
+  DestinationRequest,
+  NewDestination,
   IncidentPK,
   BulkEventWithoutDescriptionBody,
   BulkEventBody,
@@ -125,17 +131,17 @@ class ApiClient {
           const { status } = error.response;
           const { url } = error.response.config; // endpoint relative url that was requested
           const { data } = error.response; // error cause message
-          
+
           if (status === 401) {
             unauthorizedCallback(error.response, error);
           } else if (status >= 500 && status <= 599) {
             serverErrorCallback(error.response, error);
-          } else if (url.includes('/automatic-ticket/') && (status >= 500 && status <= 599)) {
+          } else if (url.includes("/automatic-ticket/") && status >= 500 && status <= 599) {
             pluginErrorCallback(error.response, error);
-          } else if (url.includes('/automatic-ticket/') && typeof data === 'string' && data.includes('No path to')) {
+          } else if (url.includes("/automatic-ticket/") && typeof data === "string" && data.includes("No path to")) {
             pluginErrorCallback(error.response, error);
-          } else if (url.includes('/automatic-ticket/')) {
-            pluginErrorCallback(error.response, 'Please, create ticket manually')
+          } else if (url.includes("/automatic-ticket/")) {
+            pluginErrorCallback(error.response, "Please, create ticket manually");
           }
         }
         return Promise.reject(error);
@@ -245,7 +251,9 @@ class ApiClient {
   // NotificationProfile
   public getNotificationProfile(pk: NotificationProfilePK): Promise<NotificationProfileSuccessResponse> {
     return this.resolveOrReject(
-      this.authGet<NotificationProfileSuccessResponse, GetNotificationProfileRequest>(`/api/v2/notificationprofile/${pk}/`),
+      this.authGet<NotificationProfileSuccessResponse, GetNotificationProfileRequest>(
+        `/api/v2/notificationprofile/${pk}/`,
+      ),
       defaultResolver,
       (error) => new Error(`Failed to get notification profile: ${getErrorCause(error)}`),
     );
@@ -253,7 +261,9 @@ class ApiClient {
 
   public getAllNotificationProfiles(): Promise<NotificationProfileSuccessResponse[]> {
     return this.resolveOrReject(
-      this.authGet<NotificationProfileSuccessResponse[], GetNotificationProfileRequest>(`/api/v2/notificationprofiles/`),
+      this.authGet<NotificationProfileSuccessResponse[], GetNotificationProfileRequest>(
+        `/api/v2/notificationprofiles/`,
+      ),
       defaultResolver,
       (error) => new Error(`Failed to get notification profiles: ${getErrorCause(error)}`),
     );
@@ -319,51 +329,54 @@ class ApiClient {
   // Destinations
   public getAllMedia(): Promise<Media[]> {
     return this.resolveOrReject(
-        this.authGet<Media[], never>(`/api/v2/notificationprofiles/media/`),
-        defaultResolver,
-        (error) => new Error(`Failed to get configured media: ${getErrorCause(error)}`),
+      this.authGet<Media[], never>(`/api/v2/notificationprofiles/media/`),
+      defaultResolver,
+      (error) => new Error(`Failed to get configured media: ${getErrorCause(error)}`),
     );
   }
 
   public getAllDestinations(): Promise<Destination[]> {
     return this.resolveOrReject(
-        this.authGet<Destination[], never>(`/api/v2/notificationprofiles/destinations/`),
-        defaultResolver,
-        (error) => new Error(`Failed to get destinations: ${getErrorCause(error)}`),
+      this.authGet<Destination[], never>(`/api/v2/notificationprofiles/destinations/`),
+      defaultResolver,
+      (error) => new Error(`Failed to get destinations: ${getErrorCause(error)}`),
     );
   }
 
   public getMediaSchemaBySlug(slug: string): Promise<MediaSchema> {
     return this.resolveOrReject(
-        this.authGet<MediaSchema, string>(`/api/v2/notificationprofiles/media/${slug}/json_schema/`),
-        defaultResolver,
-        (error) => new Error(`Failed to get media schema of type ${slug}: ${getErrorCause(error)}`),
+      this.authGet<MediaSchema, string>(`/api/v2/notificationprofiles/media/${slug}/json_schema/`),
+      defaultResolver,
+      (error) => new Error(`Failed to get media schema of type ${slug}: ${getErrorCause(error)}`),
     );
   }
 
   // Create new destination
   public postDestination(destination: NewDestination): Promise<Destination> {
     return this.resolveOrReject(
-        this.authPost<Destination, NewDestination>(`/api/v2/notificationprofiles/destinations/`, destination),
-        defaultResolver,
-        (error) => new Error(`Failed to create destination ${destination.label}: ${getErrorCause(error)}`),
+      this.authPost<Destination, NewDestination>(`/api/v2/notificationprofiles/destinations/`, destination),
+      defaultResolver,
+      (error) => new Error(`Failed to create destination ${destination.label}: ${getErrorCause(error)}`),
     );
   }
 
   public deleteDestination(destinationPk: DestinationPK): Promise<void> {
     return this.resolveOrReject(
-        this.authDelete<never, DestinationPK>(`/api/v2/notificationprofiles/destinations/${destinationPk}`),
-        defaultResolver,
-        (error) => new Error(`Failed to delete destination ${destinationPk}: ${getErrorCause(error)}`),
+      this.authDelete<never, DestinationPK>(`/api/v2/notificationprofiles/destinations/${destinationPk}`),
+      defaultResolver,
+      (error) => new Error(`Failed to delete destination ${destinationPk}: ${getErrorCause(error)}`),
     );
   }
 
   // Update existing destination destination
   public putDestination(destination: DestinationRequest): Promise<Destination> {
     return this.resolveOrReject(
-        this.authPatch<Destination, DestinationRequest>(`/api/v2/notificationprofiles/destinations/${destination.pk}/`, destination),
-        defaultResolver,
-        (error) => new Error(`Failed to update destination ${destination.pk}: ${getErrorCause(error)}`),
+      this.authPatch<Destination, DestinationRequest>(
+        `/api/v2/notificationprofiles/destinations/${destination.pk}/`,
+        destination,
+      ),
+      defaultResolver,
+      (error) => new Error(`Failed to update destination ${destination.pk}: ${getErrorCause(error)}`),
     );
   }
 
@@ -372,7 +385,7 @@ class ApiClient {
       this.authPost<Event, EventWithoutDescriptionBody>(`/api/v1/incidents/${pk}/events/`, { type: EventType.REOPEN }),
       defaultResolver,
       (error) => {
-        throw new Error(`Failed to post incident reopen event: ${getErrorCause(error)}`)
+        throw new Error(`Failed to post incident reopen event: ${getErrorCause(error)}`);
       },
     );
   }
@@ -400,7 +413,7 @@ class ApiClient {
         description
           ? {
               type: EventType.CLOSE,
-              description
+              description,
             }
           : { type: EventType.CLOSE },
       ),
@@ -422,78 +435,85 @@ class ApiClient {
 
   public putCreateTicketEvent(incidentPK: number): Promise<IncidentTicketUrlBody> {
     return this.resolveOrReject(
-        this.authPut<IncidentTicketUrlBody, never>(`/api/v2/incidents/${incidentPK}/automatic-ticket/`),
-        defaultResolver,
-        (error) => error,
+      this.authPut<IncidentTicketUrlBody, never>(`/api/v2/incidents/${incidentPK}/automatic-ticket/`),
+      defaultResolver,
+      (error) => error,
     );
   }
 
   // Bulk actions on incidents
   public bulkPostIncidentReopenEvent(pks: IncidentPK[], timestamp: Timestamp): Promise<{ changes: Event }> {
     return this.resolveOrReject(
-        this.authPost<{ changes: Event }, BulkEventWithoutDescriptionBody>(`/api/v2/incidents/events/bulk/`, {
-          ids: pks,
-          event: {
-            type: EventType.REOPEN
-          },
-          timestamp,
-        }
-        ),
-        defaultResolver,
-        (error) => {
-          throw new Error(`Failed to bulk post incident reopen event: ${getErrorCause(error)}`)
+      this.authPost<{ changes: Event }, BulkEventWithoutDescriptionBody>(`/api/v2/incidents/events/bulk/`, {
+        ids: pks,
+        event: {
+          type: EventType.REOPEN,
         },
+        timestamp,
+      }),
+      defaultResolver,
+      (error) => {
+        throw new Error(`Failed to bulk post incident reopen event: ${getErrorCause(error)}`);
+      },
     );
   }
 
-  public bulkPostIncidentCloseEvent(pks: IncidentPK[], timestamp: Timestamp,  description?: string): Promise<{ changes: Event }> {
+  public bulkPostIncidentCloseEvent(
+    pks: IncidentPK[],
+    timestamp: Timestamp,
+    description?: string,
+  ): Promise<{ changes: Event }> {
     return this.resolveOrReject(
-        this.authPost<{ changes: Event }, BulkEventBody | BulkEventWithoutDescriptionBody>(
-            `/api/v2/incidents/events/bulk/`,
-            description
-                ?
-                {
-                  ids: pks,
-                  event: {
-                    type: EventType.CLOSE,
-                    description,
-                  },
-                  timestamp,
-                }
-                :
-                {
-                  ids: pks,
-                  event: {
-                    type: EventType.CLOSE
-                  },
-                  timestamp,
-                },
-        ),
-        defaultResolver,
-        (error) => new Error(`Failed to bulk post incident close event: ${getErrorCause(error)}`),
+      this.authPost<{ changes: Event }, BulkEventBody | BulkEventWithoutDescriptionBody>(
+        `/api/v2/incidents/events/bulk/`,
+        description
+          ? {
+              ids: pks,
+              event: {
+                type: EventType.CLOSE,
+                description,
+              },
+              timestamp,
+            }
+          : {
+              ids: pks,
+              event: {
+                type: EventType.CLOSE,
+              },
+              timestamp,
+            },
+      ),
+      defaultResolver,
+      (error) => new Error(`Failed to bulk post incident close event: ${getErrorCause(error)}`),
     );
   }
 
   public bulkPatchIncidentTicketUrl(pks: IncidentPK[], ticketUrl: string): Promise<{ changes: IncidentTicketUrlBody }> {
     return this.resolveOrReject(
-        this.authPost<{ changes: IncidentTicketUrlBody }, IncidentTicketUrlBody & { ids: IncidentPK[]}>(`/api/v2/incidents/ticket_url/bulk/`, {
+      this.authPost<{ changes: IncidentTicketUrlBody }, IncidentTicketUrlBody & { ids: IncidentPK[] }>(
+        `/api/v2/incidents/ticket_url/bulk/`,
+        {
           // eslint-disable-next-line @typescript-eslint/camelcase
           ids: pks,
           ticket_url: ticketUrl,
-        }),
-        defaultResolver,
-        (error) => new Error(`Failed to bulk put incident ticket url: ${getErrorCause(error)}`),
+        },
+      ),
+      defaultResolver,
+      (error) => new Error(`Failed to bulk put incident ticket url: ${getErrorCause(error)}`),
     );
   }
 
   public bulkPostAck(pks: IncidentPK[], ack: AcknowledgementBody): Promise<{ changes: Acknowledgement }> {
     return this.resolveOrReject(
-        this.authPost<{ changes: Acknowledgement }, { ids: IncidentPK[], ack: AcknowledgementBody }>(`/api/v2/incidents/acks/bulk/`, {
+      this.authPost<{ changes: Acknowledgement }, { ids: IncidentPK[]; ack: AcknowledgementBody }>(
+        `/api/v2/incidents/acks/bulk/`,
+        {
           ids: pks,
-          ack
-        }),
-        defaultResolver,
-        (error) => new Error(`Failed to bulk post incident ack: ${getErrorCause(error)}`),
+          ack,
+        },
+      ),
+      defaultResolver,
+      (error) => new Error(`Failed to bulk post incident ack: ${getErrorCause(error)}`),
     );
   }
 
@@ -632,8 +652,8 @@ class ApiClient {
               filter.maxlevel = undefined;
             }
 
-            filter.sourceSystemIds = definition.sourceSystemIds
-            filter.tags = definition.tags
+            filter.sourceSystemIds = definition.sourceSystemIds;
+            filter.tags = definition.tags;
 
             return {
               pk: resp.pk,
@@ -653,7 +673,7 @@ class ApiClient {
     };
 
     const filterString = JSON.stringify(definition) as string;
-    console.log(filterString)
+    console.log(filterString);
 
     return this.resolveOrReject(
       this.authPost<FilterSuccessResponse, FilterRequest>(`/api/v1/notificationprofiles/filters/`, {
@@ -674,7 +694,7 @@ class ApiClient {
     };
 
     const filterString = JSON.stringify(definition) as string;
-    console.log(filterString)
+    console.log(filterString);
 
     return this.resolveOrReject(
       this.authPut<FilterSuccessResponse, FilterRequest>(`/api/v1/notificationprofiles/filters/${filter.pk}/`, {
@@ -747,12 +767,12 @@ class ApiClient {
     );
   }
 
-  public getMetadataConfig() : Promise<MetadataConfig> {
+  public getMetadataConfig(): Promise<MetadataConfig> {
     return this.resolveOrReject(
-        this.authGet<MetadataConfig, never>(`/api/`),
-        defaultResolver,
-        (error) =>  new Error(`Failed to get metadata config: ${getErrorCause(error)}`),
-    )
+      this.authGet<MetadataConfig, never>(`/api/`),
+      defaultResolver,
+      (error) => new Error(`Failed to get metadata config: ${getErrorCause(error)}`),
+    );
   }
 
   private post<T, B, R = AxiosResponse<T>>(url: string, data?: B, config?: AxiosRequestConfig): Promise<R> {

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -78,7 +78,6 @@ export interface FilterString {
   // show?: "open" | "closed" | "both";
 }
 
-export type MediaAlternative = "EM" | "SM";
 
 export type PhoneNumberPK = number;
 
@@ -96,9 +95,8 @@ export type NotificationProfilePK = number;
 export interface NotificationProfileKeyed {
   timeslot: TimeslotPK;
   filters: FilterPK[];
-  media: MediaAlternative[];
   active: boolean;
-  phone_number: PhoneNumber["pk"] | null;
+  destinations: Destination[] | null;
   pk?: NotificationProfilePK;
 }
 
@@ -106,10 +104,14 @@ export interface NotificationProfile {
   pk: number;
   timeslot: Timeslot;
   filters: Filter[];
-  media: MediaAlternative[];
   active: boolean;
-  phone_number: PhoneNumber | null;
+  destinations: Destination[] | null;
 }
+
+export type NotificationProfileRequest = Omit<NotificationProfileKeyed, "destinations"> & { destinations: DestinationPK[] | null };
+export type NotificationProfileSuccessResponse = NotificationProfile;
+export type GetNotificationProfileRequest = Pick<NotificationProfile, "pk">;
+export type DeleteNotificationProfileRequest = Pick<NotificationProfile, "pk">;
 
 /*
  * Destinations
@@ -127,6 +129,13 @@ export type MediaProperty = {
   type: string; // value type
   description?: string;
   format?: string;
+}
+
+export enum KnownProperties {
+  PHONE_NUMBER = "phone_number",
+  EMAIL = "email_address",
+  SYNCED = "synced",
+  MS_TEAMS = "webhook",
 }
 
 export type MediaSchema = {
@@ -265,11 +274,6 @@ export type IncidentsFilterOptions = {
   filter: FilterContent;
   // NOT COMPLETE
 };
-
-export type NotificationProfileRequest = NotificationProfileKeyed;
-export type NotificationProfileSuccessResponse = NotificationProfile;
-export type GetNotificationProfileRequest = Pick<NotificationProfileRequest, "timeslot">;
-export type DeleteNotificationProfileRequest = Pick<NotificationProfileRequest, "timeslot">;
 
 export type FilterRequest = {
   name: string;

--- a/src/components/notificationprofile/NotificationProfileCard.test.tsx
+++ b/src/components/notificationprofile/NotificationProfileCard.test.tsx
@@ -6,10 +6,8 @@ import userEvent from "@testing-library/user-event";
 import {
   Destination,
   Filter,
-  KnownProperties,
   Media,
   NotificationProfileKeyed,
-  PhoneNumber,
   Timeslot
 } from "../../api/types";
 import NotificationProfileCard from "./NotificationProfileCard";

--- a/src/components/notificationprofile/NotificationProfileCard.test.tsx
+++ b/src/components/notificationprofile/NotificationProfileCard.test.tsx
@@ -11,7 +11,6 @@ import {
   Timeslot
 } from "../../api/types";
 import NotificationProfileCard from "./NotificationProfileCard";
-import {destinationPKsToDestinations} from "../../utils";
 
 // MOCK DATA INPUT TO COMPONENT
 const timeslots: Timeslot[] = [
@@ -49,7 +48,6 @@ const filters: Filter[] = [
 const media: Media[] = [
   { slug: "email", name: "Email" },
   { slug: "sms", name: "SMS" },
-  { slug: "ms_teams", name: "MS Teams" },
 ];
 
 const destinationsArray: Destination[] = [
@@ -82,15 +80,6 @@ const destinationsArray: Destination[] = [
       synced: true
     }
   },
-  {
-    pk: 4,
-    label: "test_msteams",
-    media: media[2],
-    suggested_label: "MS Teams: MS TEAMS #4",
-    settings: {
-      webhook: "https://test.test"
-    }
-  },
 ]
 
 const existingProfile1: NotificationProfileKeyed = {
@@ -121,8 +110,7 @@ const newProfile: NotificationProfileKeyed = {
 
 const destinationsMap = new Map<Media["slug"], Destination[]>([
   ["sms", [destinationsArray[0]]],
-  ["email", [destinationsArray[1], destinationsArray[2]]],
-  ["ms_teams", [destinationsArray[3]]],
+  ["email", [destinationsArray[1], destinationsArray[2]]]
 ])
 
 // MOCK FUNCTIONS
@@ -186,12 +174,10 @@ describe("Rendering existing profile", () => {
     const destinationOption1 = screen.getByRole("option", {name: destinationsArray[0].settings["phone_number"] as string});
     const destinationOption2 = screen.getByRole("option", {name: destinationsArray[1].settings["email_address"] as string});
     const destinationOption3 = screen.getByRole("option", {name: destinationsArray[2].settings["email_address"] as string});
-    const destinationOption4 = screen.getByRole("option", {name: destinationsArray[3].settings["webhook"] as string});
 
     expect(destinationOption1).toBeInTheDocument();
     expect(destinationOption2).toBeInTheDocument();
     expect(destinationOption3).toBeInTheDocument();
-    expect(destinationOption4).toBeInTheDocument();
   });
 
   it("renders the active checkbox correctly", () => {
@@ -268,12 +254,10 @@ describe("Rendering new profile", () => {
     const destinationOption1 = screen.getByRole("option", {name: destinationsArray[0].settings["phone_number"] as string});
     const destinationOption2 = screen.getByRole("option", {name: destinationsArray[1].settings["email_address"] as string});
     const destinationOption3 = screen.getByRole("option", {name: destinationsArray[2].settings["email_address"] as string});
-    const destinationOption4 = screen.getByRole("option", {name: destinationsArray[3].settings["webhook"] as string});
 
     expect(destinationOption1).toBeInTheDocument();
     expect(destinationOption2).toBeInTheDocument();
     expect(destinationOption3).toBeInTheDocument();
-    expect(destinationOption4).toBeInTheDocument();
   });
 
   it("renders the active checkbox correctly", () => {
@@ -319,7 +303,7 @@ describe("Functionality", () => {
       ...existingProfile2,
       filters: [1, 2],
       // eslint-disable-next-line @typescript-eslint/camelcase
-      destinations: [destinationsArray[1], destinationsArray[2], destinationsArray[3]],
+      destinations: [destinationsArray[0], destinationsArray[1], destinationsArray[2]],
       active: false,
     };
 
@@ -336,7 +320,7 @@ describe("Functionality", () => {
 
     // Change destination
     userEvent.click(destinationsSelector);
-    const destinationOption4 = screen.getByRole("option", {name: destinationsArray[3].settings["webhook"] as string});
+    const destinationOption4 = screen.getByRole("option", {name: destinationsArray[0].settings["phone_number"] as string});
     userEvent.click(destinationOption4);
 
     // Uncheck active

--- a/src/components/notificationprofile/NotificationProfileCard.tsx
+++ b/src/components/notificationprofile/NotificationProfileCard.tsx
@@ -42,14 +42,6 @@ import Input from "@material-ui/core/Input";
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
-const MenuProps = {
-  PaperProps: {
-    style: {
-      maxHeight: ITEM_HEIGHT * 6.5 + ITEM_PADDING_TOP,
-      width: 350,
-    },
-  },
-};
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -271,7 +263,16 @@ const NotificationProfileCard = ({
                   onChange={handleDestinationsChange}
                   input={<Input/>}
                   renderValue={(selected) => (destinationPKsToDestinations(selected as DestinationPK[], destinations)).map(d => d.suggested_label).join(', ')}
-                  MenuProps={MenuProps}
+                  MenuProps={{
+                    variant: "menu",
+                    getContentAnchorEl: null,
+                    PaperProps: {
+                      style: {
+                        maxHeight: ITEM_HEIGHT * 6.5 + ITEM_PADDING_TOP,
+                        width: 350,
+                      },
+                    },
+                  }}
               >
 
                 {Array.from(destinations).map(([slug, dests]) => {

--- a/src/components/notificationprofile/NotificationProfileCard.tsx
+++ b/src/components/notificationprofile/NotificationProfileCard.tsx
@@ -262,6 +262,7 @@ const NotificationProfileCard = ({
             <Typography className={style.itemHeader}>Destinations</Typography>
             <div className={style.phoneNumber}>
               <Select
+                  data-testid="destinations-selector"
                   className={style.phoneNumberSelect}
                   labelId="destinations-selector"
                   id="destinations-selector"

--- a/src/components/notificationprofile/NotificationProfileCard.tsx
+++ b/src/components/notificationprofile/NotificationProfileCard.tsx
@@ -92,6 +92,10 @@ const useStyles = makeStyles(() =>
     chip: {
       margin: 2,
     },
+    mediaSubheader: {
+      zIndex: 1,
+      backgroundColor: "#fff",
+    },
   }),
 );
 
@@ -277,7 +281,7 @@ const NotificationProfileCard = ({
 
                 {Array.from(destinations).map(([slug, dests]) => {
                   return [
-                    <ListSubheader>{mediaSlugToMediaName(slug, mediaOptions)}</ListSubheader>,
+                    <ListSubheader className={style.mediaSubheader}>{mediaSlugToMediaName(slug, mediaOptions)}</ListSubheader>,
                     dests.map(destination => (
                           <MenuItem key={destination.pk} value={destination.pk}>
                             <Checkbox checked={selectedDestinations.indexOf(destination.pk) > -1} />

--- a/src/components/notificationprofile/NotificationProfileList.test.tsx
+++ b/src/components/notificationprofile/NotificationProfileList.test.tsx
@@ -4,7 +4,8 @@ import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
-    Filter,
+    Destination,
+    Filter, Media,
     NotificationProfile,
     PhoneNumber,
     Timeslot
@@ -38,20 +39,42 @@ const filters: Filter[] = [
     },
 ];
 
-const phoneNumbers: PhoneNumber[] = [
+const media: Media[] = [
+    { slug: "email", name: "Email" },
+    { slug: "sms", name: "SMS" },
+];
+
+const destinationsArray: Destination[] = [
     {
         pk: 1,
-        user: 1,
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        phone_number: "+4712345678",
+        label: "test_sms",
+        media: media[1],
+        suggested_label: "SMS: +4747474747",
+        settings: {
+            phone_number: "+4747474747"
+        }
     },
     {
         pk: 2,
-        user: 1,
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        phone_number: "+4787654321",
+        label: "test_email",
+        media: media[0],
+        suggested_label: "Email: test@test.test",
+        settings: {
+            email_address: "test@test.test",
+            synced: false
+        }
     },
-];
+    {
+        pk: 3,
+        label: "test_email_synced",
+        media: media[0],
+        suggested_label: "Email: synced@test.test",
+        settings: {
+            email_address: "synced@test.test",
+            synced: true
+        }
+    },
+]
 
 
 // For avoiding authentication errors
@@ -80,8 +103,8 @@ describe("Rendering profile list with no existing timeslots", () => {
             .reply(200, [] as Timeslot[])
             .onGet("/api/v2/notificationprofiles/filters/")
             .reply(200, filters as Filter[])
-            .onGet("/api/v2/auth/phone-number/")
-            .reply(200, phoneNumbers as PhoneNumber[]);
+            .onGet("/api/v2/notificationprofiles/destinations/")
+            .reply(200, destinationsArray as Destination[]);
 
         render(
             <NotificationProfileList/>,

--- a/src/components/notificationprofile/NotificationProfileList.test.tsx
+++ b/src/components/notificationprofile/NotificationProfileList.test.tsx
@@ -5,9 +5,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
     Filter,
-    MediaAlternative,
     NotificationProfile,
-    NotificationProfileKeyed,
     PhoneNumber,
     Timeslot
 } from "../../api/types";
@@ -76,13 +74,13 @@ describe("Rendering profile list with no existing timeslots", () => {
             .onGet("/api/v1/auth/user/")
             // eslint-disable-next-line @typescript-eslint/camelcase
             .reply(200, { username: "test", first_name: "test", last_name: "test", email: "test" })
-            .onGet("/api/v1/notificationprofiles/")
+            .onGet("/api/v2/notificationprofiles/")
             .reply(200, [] as NotificationProfile[])
-            .onGet("/api/v1/notificationprofiles/timeslots/")
+            .onGet("/api/v2/notificationprofiles/timeslots/")
             .reply(200, [] as Timeslot[])
-            .onGet("/api/v1/notificationprofiles/filters/")
+            .onGet("/api/v2/notificationprofiles/filters/")
             .reply(200, filters as Filter[])
-            .onGet("/api/v1/auth/phone-number/")
+            .onGet("/api/v2/auth/phone-number/")
             .reply(200, phoneNumbers as PhoneNumber[]);
 
         render(

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -4,7 +4,7 @@ import format from "date-fns/format";
 import formatDistance from "date-fns/formatDistance";
 
 // Api
-import type {Incident, User, Token, DestinationSettings} from "./api/types.d";
+import type {Incident, User, Token} from "./api/types.d";
 import api from "./api";
 import auth from "./auth";
 
@@ -305,7 +305,7 @@ export const destinationPKsToDestinations = (destinationPKs: DestinationPK[] | n
   if (destinationPKs !== null) {
     destinationsMapToArray(destinations)
         .filter((d) => destinationPKs.indexOf(d.pk) !== -1)
-        .map((d) => {
+        .forEach((d) => {
           if (res.indexOf(d) === -1) {
             res.push(d);
           }


### PR DESCRIPTION
### Changes made in _Notification profiles:_

- Removed _Media_-selector
- Replaced _Phone number_-selector with _Destinations_-selector
- Notification profiles operate with destinations instead of phone number

### Notable details about the _Destinations_-selector:

- User can now chose **multiple** destinations per notification profile
- Destinations menu items names are either a label (user-given destination name), or a _suggested label_ (set by backend, f.e "SMS: +XXXXXXXXXX"), or an actual settings value (f.e. actual phone number, or email). But on hover event over a destination menu iten, the actual settings value (f.e. actual phone number, or email) will be displayed in a tooltip.
- Destination in the menu have checkboxes and are divided in categories after the media type that destinations belong to.

NB! The _Pluss_-button still opens a create new phone menu instead of a new destination emu. Fixing this should be a separate issue #481 after #475 is merged.

**NB! This PR is dependent on #474.**
