### PR TITLE
Replace AddPhoneNumber with AddDestination

### DIFF
--- a/src/components/notificationprofile/AddDestinationDialog.tsx
+++ b/src/components/notificationprofile/AddDestinationDialog.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import Modal from "../modal/Modal";
+import { Media, NewDestination } from "../../api/types";
+import NewDestinationComponent from "../destinations/NewDestination";
+
+type AddDestinationDialogPropsType = {
+  open: boolean;
+  configuredMedia: Media[];
+  onSave: (destination: NewDestination) => Promise<void>;
+  onCancel: () => void;
+};
+
+const AddDestinationDialog = ({ open, onSave, configuredMedia, onCancel }: AddDestinationDialogPropsType) => {
+  return (
+    <Modal
+      title="Add destination"
+      content={<NewDestinationComponent configuredMedia={configuredMedia} onCreate={onSave} isModal={true} />}
+      open={open}
+      onClose={onCancel}
+    />
+  );
+};
+
+export default AddDestinationDialog;


### PR DESCRIPTION
Changes made:

- Clicking on _pluss-button_ in Notification Profiles will prompt a new add destination component (instead of the add phone number component)
- All use of phone numbers is removed/replaced (tests, styles, components, types, api calls etc), except of phone numbers as a part of destinations

Closes #481 