### PR TITLE
Improve error handling in Login view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 
 ## [Unreleased]
 
+### Added
+- Handling of both network errors, and errors with fetching existing user in _Login view_ .
+
 
 ### Fixed
 - Bug with misleading error message in Login view on connection problems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ This file documents all changes to Argus-frontend. This file is primarily meant 
 
 ## [Unreleased]
 
+
+### Fixed
+- Bug with misleading error message in Login view on connection problems.
+
+
+
+
 ## [v1.9.0] - 2023-03-17
 
 ### Changed

--- a/NOTES.md
+++ b/NOTES.md
@@ -4,6 +4,10 @@ This file documents changes to Argus-frontend that are important for the users t
 
 ## [Unreleased]
 
+### Added
+- Handling of both network errors, and errors with fetching existing user in _Login view_ .
+
+
 ### Fixed
 - Bug with misleading error message in Login view on connection problems.
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -4,6 +4,12 @@ This file documents changes to Argus-frontend that are important for the users t
 
 ## [Unreleased]
 
+### Fixed
+- Bug with misleading error message in Login view on connection problems.
+
+
+
+
 ## [v1.9.0] - 2023-03-17
 
 ### Changed

--- a/src/components/alerts/AlertAppbar.test.tsx
+++ b/src/components/alerts/AlertAppbar.test.tsx
@@ -1,0 +1,69 @@
+/**  * @jest-environment jsdom-sixteen  */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AlertAppbar from "./AlertAppbar";
+
+const messageText = "TEST";
+
+const colors = {
+  text: "white",
+  errorBackground: "rgb(211, 47, 47)",
+  warningBackground: "rgb(245, 124, 0)",
+  defaultBackground: "rgb(48, 63, 159)",
+};
+
+describe("Alert Appbar test suite", () => {
+  test("alert message text is rendered correctly", () => {
+    render(<AlertAppbar message={messageText} severity={"info"} />);
+
+    const appbar = screen.getByRole("banner");
+    expect(appbar).toBeInTheDocument();
+    expect(appbar).toHaveTextContent(messageText);
+  });
+
+  test("error alert color is rendered correctly", async () => {
+    const { findByRole, findByText } = render(<AlertAppbar message={messageText} severity={"error"} />);
+
+    document.head.innerHTML = document.head.innerHTML;
+
+    const banner = await findByRole("banner");
+    expect(banner).toBeInTheDocument();
+
+    const typography = await findByText(messageText);
+    expect(typography).toBeInTheDocument();
+
+    expect(banner).toHaveStyle(`background-color: ${colors.errorBackground}`);
+    expect(typography).toHaveStyle(`color: ${colors.text}`);
+  });
+
+  test("warning alert color is rendered correctly", async () => {
+    const { findByRole, findByText } = render(<AlertAppbar message={messageText} severity={"warning"} />);
+
+    document.head.innerHTML = document.head.innerHTML;
+
+    const banner = await findByRole("banner");
+    expect(banner).toBeInTheDocument();
+
+    const typography = await findByText(messageText);
+    expect(typography).toBeInTheDocument();
+
+    expect(banner).toHaveStyle(`background-color: ${colors.warningBackground}`);
+    expect(typography).toHaveStyle(`color: ${colors.text}`);
+  });
+
+  test("info alert color is rendered correctly", async () => {
+    const { findByRole, findByText } = render(<AlertAppbar message={messageText} severity={"info"} />);
+
+    document.head.innerHTML = document.head.innerHTML;
+
+    const banner = await findByRole("banner");
+    expect(banner).toBeInTheDocument();
+
+    const typography = await findByText(messageText);
+    expect(typography).toBeInTheDocument();
+
+    expect(banner).toHaveStyle(`background-color: ${colors.defaultBackground}`);
+    expect(typography).toHaveStyle(`color: ${colors.text}`);
+  });
+});

--- a/src/components/alerts/AlertAppbar.tsx
+++ b/src/components/alerts/AlertAppbar.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+import classNames from "classnames";
+import Typography from "@material-ui/core/Typography";
+import AppBar from "@material-ui/core/AppBar";
+import {createStyles, makeStyles, Theme} from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      boxSizing: "border-box",
+      color: theme.palette.text.primary,
+      flexGrow: 1,
+      transition: "0.4s",
+      zIndex: theme.zIndex.drawer + 1,
+    },
+    rootDefault: {
+      backgroundColor: theme.palette.primary.dark,
+    },
+    rootNetworkError: {
+      backgroundColor: theme.palette.error.dark,
+    },
+    rootWarningMessage: {
+      backgroundColor: theme.palette.warning.dark,
+    },
+    container: {
+      display: "flex",
+      flexFlow: "column wrap",
+      alignItems: "center",
+      margin: "4px",
+    },
+    typography: {
+      alignItems: "center",
+      fontWeight: "bold",
+      color: "white",
+    },
+  }),
+);
+
+export type AlertAppbarSeverity = "error" | "warning" | "info" | "success";
+
+export type AlertAppbarPropsType = {
+  message: string;
+  severity: AlertAppbarSeverity;
+};
+
+const AlertAppbar: React.SFC<AlertAppbarPropsType> = ({
+                                                            message,
+                                                            severity,
+                                                          }: AlertAppbarPropsType): React.ReactElement => {
+
+  const style = useStyles();
+
+  const getStyleBySeverity  = () : string  => {
+      switch (severity) {
+        case "error":
+          return style.rootNetworkError;
+        case "warning":
+          return style.rootWarningMessage;
+        default:
+          return style.rootDefault;
+      }
+  };
+
+  return (
+    <AppBar className={classNames(style.root, getStyleBySeverity())} position="relative">
+      <div className={style.container}>
+        <Typography className={style.typography}>
+          {message}
+        </Typography>
+      </div>
+    </AppBar>
+  );
+};
+
+export default AlertAppbar;

--- a/src/components/apiinterceptor.tsx
+++ b/src/components/apiinterceptor.tsx
@@ -43,8 +43,11 @@ export const ApiInterceptor = ({ children }: { children?: React.ReactNode }) => 
           const { response, error } = event;
           if (!response.response || !response.response.status) {
             dispatch(setHasConnectionProblems());
+            console.error("caught network error", response, error);
+          } else {
+            dispatch(unsetHasConnectionProblems());
+            console.error("caught error", response, error);
           }
-          console.error("caught network error", response, error);
           break;
         }
         case "success": {

--- a/src/components/apiinterceptor.tsx
+++ b/src/components/apiinterceptor.tsx
@@ -44,7 +44,7 @@ export const ApiInterceptor = ({ children }: { children?: React.ReactNode }) => 
           if (!response.response || !response.response.status) {
             dispatch(setHasConnectionProblems());
           }
-          console.error("catched network error", response, error);
+          console.error("caught network error", response, error);
           break;
         }
         case "success": {

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -29,6 +29,7 @@ import { useApiState, useUser } from "../../state/hooks";
 // Components
 import Menu from "../../components/menu";
 import Logo from "../logo/Logo";
+import AlertAppbar from "../alerts/AlertAppbar";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -39,12 +40,6 @@ const useStyles = makeStyles((theme: Theme) =>
       flexGrow: 1,
       transition: "0.4s",
       zIndex: theme.zIndex.drawer + 1,
-    },
-    rootNetworkError: {
-      backgroundColor: theme.palette.error.dark,
-    },
-    rootInfoMessage: {
-        backgroundColor: theme.palette.warning.dark,
     },
     grow: { flexGrow: 1 },
     rightAligned: { marginRight: theme.spacing(2) },
@@ -103,28 +98,6 @@ const useStyles = makeStyles((theme: Theme) =>
       "&:hover": {
         cursor: "pointer",
       },
-    },
-    errorContainer: {
-      display: "flex",
-      flexFlow: "column wrap",
-      alignItems: "center",
-      margin: "4px",
-    },
-    errorTypography: {
-      alignItems: "center",
-      fontWeight: "bold",
-      color: "white",
-    },
-    infoContainer: {
-        display: "flex",
-        flexFlow: "column wrap",
-        alignItems: "center",
-        margin: "4px",
-    },
-    infoTypography: {
-        alignItems: "center",
-        fontWeight: "bold",
-        color: "white",
     },
   }),
 );
@@ -338,24 +311,15 @@ const Header: React.FC<HeaderPropsType> = () => {
         {mobileView ? displayMobile() : displayDesktop()}
       </AppBar>
       {apiState.hasConnectionProblems && (
-        <AppBar className={classNames(style.root, style.rootNetworkError)} position="relative">
-          <div className={style.errorContainer}>
-            <Typography className={style.errorTypography}>
-              Problems connecting to server... Check your connection.
-            </Typography>
-          </div>
-        </AppBar>
+        <AlertAppbar
+          message={"Problems connecting to server... Check your connection."}
+          severity={"error"}/>
       )}
       {apiState.isOngoingBulkUpdate && (
-          <AppBar className={classNames(style.root, style.rootInfoMessage)} position="relative">
-              <div className={style.infoContainer}>
-                  <Typography className={style.infoTypography}>
-                      Performing bulk operation... Please wait.
-                  </Typography>
-              </div>
-          </AppBar>
+        <AlertAppbar
+          message={"Performing bulk operation... Please wait."}
+          severity={"warning"}/>
       )}
-
       {renderMenu}
 
       {showDropdownNavbar && (

--- a/src/components/login/Login.test.tsx
+++ b/src/components/login/Login.test.tsx
@@ -80,15 +80,19 @@ describe("Functionality of LoginForm", () => {
     expect(message).toBeInTheDocument();
   });
 
-  it("displays error message when authentication is valid, but user is not found", async () => {
-    apiMock.onPost("/api/v1/token-auth/").reply(200, { token: "token" }).onGet("/api/v1/auth/user/").reply(404);
+  it("does not display wrong credentials helper text when authentication is valid, but user is not found", async () => {
+    apiMock
+      .onPost("/api/v1/token-auth/")
+      .reply(200, {token: "token"})
+      .onGet("/api/v1/auth/user/")
+      .reply(400);
 
-    render(<LoginForm />);
+    render(<LoginForm/>);
 
-    await userEvent.click(screen.getByRole("button"));
-    const message = await screen.findByText(/wrong username or password/i);
+    userEvent.click(screen.getByRole("button"));
 
-    expect(message).toBeInTheDocument();
+    const helperText = screen.queryByText(/wrong username or password/i);
+    expect(helperText).toBeNull();
   });
 
   it("redirects the user when login is successful", async () => {

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -149,8 +149,9 @@ const LoginForm: React.FC<{}> = () => {
             login(resUser);
             history.push("/");
           })
-          .catch((error) => {
+          .catch(async (error) => {
             displayAlert(error.message, "error");
+            await logUserOut();
           })
       });
     } else {

--- a/src/views/login/LoginView.test.tsx
+++ b/src/views/login/LoginView.test.tsx
@@ -1,0 +1,52 @@
+/**  * @jest-environment jsdom-sixteen  */
+
+import React from "react";
+import api from "../../api";
+import MockAdapter from "axios-mock-adapter";
+import LoginView from "./LoginView";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mocks of critical functions and modules
+const apiMock = new MockAdapter(api.api);
+
+afterEach(() => {
+  apiMock.reset();
+  jest.clearAllMocks();
+  jest.resetAllMocks();
+});
+
+describe("Login Page: error handling", () => {
+  it("should display wrong credentials helper text when user provides wrong credentials", async () => {
+    apiMock.onPost("/api/v1/token-auth/").reply(400);
+
+    render(<LoginView />);
+
+    await userEvent.click(screen.getByRole("button"));
+    const helperText = await screen.findByText(/wrong username or password/i);
+
+    expect(helperText).toBeInTheDocument();
+  });
+
+  it("should not display wrong credentials helper text when network connection fails", async () => {
+    apiMock.onAny().networkError();
+
+    render(<LoginView />);
+
+    await userEvent.click(screen.getByRole("button"));
+
+    const helperText = screen.queryByText(/wrong username or password/i);
+    expect(helperText).toBeNull();
+  });
+
+  it("should not display wrong credentials helper text when request to fetch user fails", async () => {
+    apiMock.onGet("/api/v1/auth/user/").reply(404);
+
+    render(<LoginView />);
+
+    await userEvent.click(screen.getByRole("button"));
+
+    const helperText = screen.queryByText(/wrong username or password/i);
+    expect(helperText).toBeNull();
+  });
+});

--- a/src/views/login/LoginView.tsx
+++ b/src/views/login/LoginView.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import { Helmet } from "react-helmet";
 
 import "./LoginView.css";
-import { createStyles, makeStyles } from "@material-ui/core/styles";
+import {createStyles, makeStyles } from "@material-ui/core/styles";
 
 import { useTheme } from "@material-ui/core/styles";
 import { useIsMobile, useBackground } from "../../hooks";
 
 import LoginForm from "../../components/login/Login";
+import {useApiState} from "../../state/hooks";
+import AlertAppbar from "../../components/alerts/AlertAppbar";
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -39,12 +41,19 @@ export const LoginView: React.FC<LoginViewPropsType> = () => {
 
   const isMobile = useIsMobile();
 
+  const [apiState] = useApiState();
+
   return (
     <div className={isMobile ? style.mobileRoot : style.root}>
       <Helmet>
         <title>Argus | Login</title>
       </Helmet>
       <div className={style.formContainer}>
+        {apiState.hasConnectionProblems && (
+          <AlertAppbar
+            message={"Problems connecting to server... Check your connection."}
+            severity={"error"}/>
+        )}
         <LoginForm />
       </div>
     </div>


### PR DESCRIPTION
### Implemented changes:
There are now 3 different ways to inform user about errors in _Login view:_
1. Error appbar in case of netwrok/server problems
2. Helper text informing about wrong credentials if userpass request failes
3. Error snackbar in case get user request fails

Closes #451 