### PR TITLE
Remove .gitkeep from ignored towncrier files

### DIFF
--- a/towncrier.toml
+++ b/towncrier.toml
@@ -6,7 +6,6 @@ underlines = ["", "", ""]
 title_format = "## [v{version}] - {project_date}"
 issue_format = "[#{issue}](https://github.com/Uninett/Argus-frontend/issues/{issue})"
 wrap = true
-ignore = [".gitkeep"]
 
 [[tool.towncrier.type]]
 directory = "security"


### PR DESCRIPTION
Since v24.8.0 gitkeep is automatically ignored