### PR TITLE
Bump python and postgres versions when running Argus in docker

### DIFF
--- a/changelog.d/586.changed.md
+++ b/changelog.d/586.changed.md
@@ -1,1 +1,1 @@
-Switched to running Argus server on python 3.9 in docker.
+Switched to running Argus server on python 3.10 and Postgres 14 in docker.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
 
   postgres:
-    image: "postgres:12"
+    image: "postgres:14"
     volumes:
       - postgres:/var/lib/postgresql/data:Z
     environment:

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,6 +1,6 @@
 # Defines a simple Argus API server running from a configurable branch or tag
 # in the upstream repo
-FROM python:3.9
+FROM python:3.10
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends tini build-essential


### PR DESCRIPTION
Using python 3.8 leads to `ERROR: Package 'argus-server' requires a different Python: 3.8.20 not in '>=3.9'`.

Closes #587, #588 