### PR TITLE
Use apt-get to install towncrier

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -14,7 +14,6 @@ jobs:
 
     - name: Install towncrier
       run: |
-        pip install -U pip
-        pip install towncrier
+        sudo apt-get install -y --no-install-recommends towncrier
     - name: Check for changelog file
       run: towncrier check --compare-with origin/master


### PR DESCRIPTION
This has become necessary due to [PEP 668](https://peps.python.org/pep-0668/).

Example where currently the towncrier check fails: https://github.com/Uninett/Argus-frontend/actions/runs/11360341158/job/31602238891?pr=586