### PR TITLE
Run nginx completely unprivileged in container

### DIFF
--- a/changelog.d/591.fixed.md
+++ b/changelog.d/591.fixed.md
@@ -1,0 +1,1 @@
+Do not run processes as `root` in Docker production container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ FROM ghcr.io/nginxinc/nginx-unprivileged:stable-alpine
 COPY --from=build /app/build /usr/share/nginx/html
 
 USER root
-RUN apk add --update tini tree
+RUN apk add --update tini
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker/docker-entrypoint.sh /
 COPY docker/runtime-config-template.json /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ FROM ghcr.io/nginxinc/nginx-unprivileged:stable-alpine
 COPY --from=build /app/build /usr/share/nginx/html
 
 USER root
-RUN apk add --update tini
+RUN apk add --no-cache --update tini
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker/docker-entrypoint.sh /
 COPY docker/runtime-config-template.json /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,14 +14,20 @@ RUN npm run build
 # production environment consisting only of nginx and the statically compiled
 # Argus Frontend application files produced by the build stage
 # FROM: https://mherman.org/blog/dockerizing-a-react-app/
-FROM nginx:stable-alpine
+FROM ghcr.io/nginxinc/nginx-unprivileged:stable-alpine
 
 COPY --from=build /app/build /usr/share/nginx/html
 
+USER root
 RUN apk add --update tini tree
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker/docker-entrypoint.sh /
 COPY docker/runtime-config-template.json /
+
+# Ensure the unprivileged nginx user can write Argus JS config
+RUN chown nginx /usr/share/nginx/html
+
+USER nginx
 
 ENV REACT_APP_BACKEND_URL=http://fake
 ENV REACT_APP_ENABLE_WEBSOCKETS_SUPPORT=true


### PR DESCRIPTION
This switches the production Docker image to use the nginx-unprivileged image as its base.  The original image would start nginx as root, while nginx itself would drop privileges to the nginx user.

This updated workflow will ensure nothing is started as root at all when the container starts.

Fixes #591